### PR TITLE
perf: use dataloader to avoid GPU waiting for workers

### DIFF
--- a/profile_executor_text.py
+++ b/profile_executor_text.py
@@ -1,0 +1,26 @@
+from time import perf_counter
+
+from docarray import DocumentArray, Document
+
+from clip_server.executors.clip_torch import CLIPEncoder
+# from clip_server.executors.clip_torch_dataloader import CLIPEncoder
+
+executor = CLIPEncoder()
+
+
+da = DocumentArray([Document(text='random text here') for _ in range(30000)])
+
+async def main():
+    await executor.encode(da)
+
+import asyncio
+st = perf_counter()
+asyncio.run(main())
+
+print('first time', perf_counter()-st)
+
+
+st = perf_counter()
+asyncio.run(main())
+
+print('second time', perf_counter()-st)

--- a/profile_server_text.py
+++ b/profile_server_text.py
@@ -1,0 +1,5 @@
+from clip_client import Client
+
+client = Client('grpc://0.0.0.0:51000')
+
+client.profile(['Hey clip please encode my text'] * 5000, request_size=5000)

--- a/server/clip_server/torch-dataloader-flow.yml
+++ b/server/clip_server/torch-dataloader-flow.yml
@@ -1,0 +1,11 @@
+jtype: Flow
+version: '1'
+with:
+  port: 51000
+executors:
+  - name: clip_t
+    uses:
+      jtype: CLIPEncoder
+      metas:
+        py_modules:
+          - executors/clip_torch_dataloader.py


### PR DESCRIPTION
Encoding and preprocessing are executed sequentially and the GPU waits until all docs are ready to be encoded.
@samsja and I wanted to avoid this by using the DataLoader from pytorch so that workers contribute in processing batches to be encoded.

`python profile_executor_text.py`

On master:
```text
cpu preprocessing 0.5129575690007186
gpu embedding 2.19830906199968
first time 2.9628389139998035
cpu preprocessing 0.5007643369999641
gpu embedding 2.184567760000391
second time 2.9293103939999128
```

feat:
```text
# feat dataloader
gpu waiting for workers 0.07661872600056086
gpu encoding 0.22060704299929057
gpu waiting for workers 0.0021561820003626053
gpu encoding 0.22138791300039884
gpu waiting for workers 0.0010702899999159854
gpu encoding 0.22121322800012422
gpu waiting for workers 9.291199967265129e-05
gpu encoding 0.22160035900014918
gpu waiting for workers 8.87120004335884e-05
gpu encoding 0.22376149100000475
gpu waiting for workers 8.738199994695606e-05
gpu encoding 0.22122334699997737
gpu waiting for workers 0.000711570000021311
gpu encoding 0.221622846000173
gpu waiting for workers 0.0011233209997953963
gpu encoding 0.2221713130002172
gpu waiting for workers 8.407299992541084e-05
gpu encoding 0.22373632800008636
gpu waiting for workers 9.173199941869825e-05
gpu encoding 0.2231302689997392
second time 2.5170462010000847
```

Currently, spawning processes for the first time takes around 1 second that's why we only care about the second execution.