### PR TITLE
fix: ignore onnxruntime-gpu on macos

### DIFF
--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -51,7 +51,7 @@ class Client:
         if _scheme == 'ws':
             _scheme = 'websocket'  # temp fix for the core
 
-        if _scheme in ('grpc', 'http', 'ws', 'websocket'):
+        if _scheme in ('grpc', 'http', 'websocket'):
             _kwargs = dict(host=r.hostname, port=_port, protocol=_scheme, https=_tls)
 
             from jina import Client
@@ -191,7 +191,7 @@ class Client:
         )
 
     def profile(self, content: Optional[str] = '') -> Dict[str, float]:
-        """Profiling a single query's roundtrip including network and compuation latency. Results is summarized in a table.
+        """Profiling a single query's roundtrip including network and computation latency. Results is summarized in a table.
 
         :param content: the content to be sent for profiling. By default it sends an empty Document
             that helps you understand the network latency.

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -58,6 +58,8 @@ class Client:
 
             self._client = Client(**_kwargs)
             self._async_client = Client(**_kwargs, asyncio=True)
+        else:
+            raise ValueError(f'{server} is not a valid scheme')
 
     @overload
     def encode(

--- a/server/setup.py
+++ b/server/setup.py
@@ -50,7 +50,9 @@ setup(
         'docarray>=0.11.0',
     ],
     extras_require={
-        'onnx': ['onnxruntime', 'onnx', 'onnxruntime-gpu'],
+        'onnx': ['onnxruntime', 'onnx'] + ['onnxruntime-gpu']
+        if sys.platform != 'darwin'
+        else [],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -7,12 +7,17 @@ from jina import Flow
 from clip_client.client import Client
 
 
-@pytest.mark.parametrize('protocol', ['grpc', 'http', 'websocket'])
+@pytest.mark.parametrize('protocol', ['grpc', 'http', 'websocket', 'other'])
 def test_protocols(port_generator, protocol, pytestconfig):
     from clip_server.executors.clip_torch import CLIPEncoder
 
     f = Flow(port=port_generator(), protocol=protocol).add(uses=CLIPEncoder)
     with f:
+        if protocol == 'other':
+            with pytest.raises(ValueError):
+                Client(server=f'{protocol}://0.0.0.0:{f.port}')
+            return
+
         c = Client(server=f'{protocol}://0.0.0.0:{f.port}')
         c.profile()
         c.profile(content='hello world')

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -11,13 +11,13 @@ from clip_client.client import Client
 def test_protocols(port_generator, protocol, pytestconfig):
     from clip_server.executors.clip_torch import CLIPEncoder
 
+    if protocol == 'other':
+        with pytest.raises(ValueError):
+            Client(server=f'{protocol}://0.0.0.0:{f.port}')
+        return
+
     f = Flow(port=port_generator(), protocol=protocol).add(uses=CLIPEncoder)
     with f:
-        if protocol == 'other':
-            with pytest.raises(ValueError):
-                Client(server=f'{protocol}://0.0.0.0:{f.port}')
-            return
-
         c = Client(server=f'{protocol}://0.0.0.0:{f.port}')
         c.profile()
         c.profile(content='hello world')

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -13,7 +13,7 @@ def test_protocols(port_generator, protocol, pytestconfig):
 
     if protocol == 'other':
         with pytest.raises(ValueError):
-            Client(server=f'{protocol}://0.0.0.0:{f.port}')
+            Client(server=f'{protocol}://0.0.0.0:8000')
         return
 
     f = Flow(port=port_generator(), protocol=protocol).add(uses=CLIPEncoder)


### PR DESCRIPTION
The following pip install cannot work on MacOS

```
pip install "clip-server[onnx]"
```

The `onnxruntime-gpu` is not available for MacOS. 