### PR TITLE
chore: fix markdown-table extention

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,4 @@
-# TODO: Remove this once the compat issue¹ is resolved.
-#
-# ¹ https://github.com/ryanfox/sphinx-markdown-tables/issues/36
+# cf. https://github.com/ryanfox/sphinx-markdown-tables/issues/36
 markdown<3.4.0
 sphinx
 sphinx-argparse==0.3.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,7 @@
+# TODO: Remove this once the compat issue¹ is resolved.
+#
+# ¹ https://github.com/ryanfox/sphinx-markdown-tables/issues/36
+markdown<3.4.0
 sphinx
 sphinx-argparse==0.3.1
 sphinxcontrib-apidoc==0.3.0


### PR DESCRIPTION
Failed to build docs due to breaking changes of markdown3.4. More details at https://github.com/ryanfox/sphinx-markdown-tables/issues/36