### PR TITLE
feat: allow model selection in client

### DIFF
--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -190,10 +190,9 @@ class Client:
 
     def _get_post_payload(self, content, kwargs):
         parameters = kwargs.get('parameters', {})
-        target_model = parameters.get('model', None)
-        endpoint = f'/encode{f"/{target_model}" if target_model else ""}'
+        model_name = parameters.get('model', '')
         payload = dict(
-            on=endpoint,
+            on=f'/encode/{model_name}',
             inputs=self._iter_doc(content),
             request_size=kwargs.get('batch_size', 8),
             total_docs=len(content) if hasattr(content, '__len__') else None,
@@ -372,10 +371,9 @@ class Client:
 
     def _get_rank_payload(self, content, kwargs):
         parameters = kwargs.get('parameters', {})
-        target_model = parameters.get('model', None)
-        endpoint = f'/rank{f"/{target_model}" if target_model else ""}'
+        model_name = parameters.get('model', '')
         payload = dict(
-            on=endpoint,
+            on=f'/encode/{model_name}',
             inputs=self._iter_rank_docs(
                 content, _source=kwargs.get('source', 'matches')
             ),

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -192,7 +192,7 @@ class Client:
         parameters = kwargs.get('parameters', {})
         model_name = parameters.get('model', '')
         payload = dict(
-            on=f'/encode/{model_name}',
+            on=f'/encode/{model_name}'.rstrip('/'),
             inputs=self._iter_doc(content),
             request_size=kwargs.get('batch_size', 8),
             total_docs=len(content) if hasattr(content, '__len__') else None,
@@ -373,7 +373,7 @@ class Client:
         parameters = kwargs.get('parameters', {})
         model_name = parameters.get('model', '')
         payload = dict(
-            on=f'/encode/{model_name}',
+            on=f'/rank/{model_name}'.rstrip('/'),
             inputs=self._iter_rank_docs(
                 content, _source=kwargs.get('source', 'matches')
             ),

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -69,6 +69,7 @@ class Client:
         *,
         batch_size: Optional[int] = None,
         show_progress: bool = False,
+        parameters: Optional[dict] = None,
     ) -> 'np.ndarray':
         """Encode images and texts into embeddings where the input is an iterable of raw strings.
         Each image and text must be represented as a string. The following strings are acceptable:
@@ -79,6 +80,7 @@ class Client:
         :param content: an iterator of image URIs or sentences, each element is an image or a text sentence as a string.
         :param batch_size: the number of elements in each request when sending ``content``
         :param show_progress: if set, show a progress bar
+        :param parameters: the parameters for the encoding, you can specify the model to use when you have multiple models
         :return: the embedding in a numpy ndarray with shape ``[N, D]``. ``N`` is in the same length of ``content``
         """
         ...
@@ -90,11 +92,13 @@ class Client:
         *,
         batch_size: Optional[int] = None,
         show_progress: bool = False,
+        parameters: Optional[dict] = None,
     ) -> 'DocumentArray':
         """Encode images and texts into embeddings where the input is an iterable of :class:`docarray.Document`.
         :param content: an iterable of :class:`docarray.Document`, each Document must be filled with `.uri`, `.text` or `.blob`.
         :param batch_size: the number of elements in each request when sending ``content``
         :param show_progress: if set, show a progress bar
+        :param parameters: the parameters for the encoding, you can specify the model to use when you have multiple models
         :return: the embedding in a numpy ndarray with shape ``[N, D]``. ``N`` is in the same length of ``content``
         """
         ...
@@ -185,8 +189,11 @@ class Client:
                 )
 
     def _get_post_payload(self, content, kwargs):
+        parameters = kwargs.get('parameters', {})
+        target_model = parameters.get('model', None)
+        endpoint = f'/encode{f"/{target_model}" if target_model else ""}'
         payload = dict(
-            on='/',
+            on=endpoint,
             inputs=self._iter_doc(content),
             request_size=kwargs.get('batch_size', 8),
             total_docs=len(content) if hasattr(content, '__len__') else None,
@@ -364,8 +371,11 @@ class Client:
                 )
 
     def _get_rank_payload(self, content, kwargs):
+        parameters = kwargs.get('parameters', {})
+        target_model = parameters.get('model', None)
+        endpoint = f'/rank{f"/{target_model}" if target_model else ""}'
         payload = dict(
-            on='/rank',
+            on=endpoint,
             inputs=self._iter_rank_docs(
                 content, _source=kwargs.get('source', 'matches')
             ),

--- a/docs/user-guides/client.md
+++ b/docs/user-guides/client.md
@@ -192,65 +192,6 @@ Use `.encode(..., show_progress=True)` to turn on the progress bar.
 Progress bar may not show up in the PyCharm debug terminal. This is an upstream issue of `rich` package.
 ```
 
-### Select model to use
-
-When you are running multiple models in the same Flow, you can override the default `requests` in `clip_server` and select which model to use in `clip_client` by setting `.encode(..., parameters={'model': 'model_name'})` or `.rank(..., parameters={'model': 'model_name'})`.
-
-
-Below is a sample YAML file to run `ViT-B/32`, `ViT-B/16` and `ViT-L/14@336px` models in the same Flow. 
-Note that `ViT-L/14@336px` is set to default if no model is specified.
-Learn more about [setting/overriding default `requests` configuration.](https://docs.jina.ai/fundamentals/flow/add-executors/#set-requests-via-uses-requests)
-
-```yaml
-jtype: Flow
-version: '1'
-with:
-  port: 51000
-  protocol: 'http'
-executors:
-  - name: ViT_B_32
-    replicas: 1
-    uses:
-      jtype: CLIPEncoder
-      with:
-        name: ViT-B/32
-      metas:
-        py_modules:
-          - clip_server.executors.clip_torch
-      requests: {'/encode/ViT-B/32': 'encode', '/': '_dry_run_func'}
-  - name: ViT_B_16
-    replicas: 1
-    uses:
-      jtype: CLIPEncoder
-      with:
-        name: ViT-B/16
-      metas:
-        py_modules:
-          - clip_server.executors.clip_torch
-      requests: { '/encode/ViT-B/16': 'encode', '/': '_dry_run_func' }
-  - name: ViT_L_14_336px
-    replicas: 1
-    uses:
-      jtype: CLIPEncoder
-      with:
-        name: ViT-L/14@336px
-      metas:
-        py_modules:
-          - clip_server.executors.clip_torch
-      requests: {'/encode': 'encode', '/encode/ViT-L/14@336px': 'encode'}
-```
-
-```{tip}
-`_dry_run_func` is a dummy function that does nothing so the first two models do not affect the result when no model is specified and the default one is used.
-```
-
-You can now specify to use `ViT-B/32` model like this:
-
-```python
-c = Client(...)
-c.encode(..., parameters={'model': 'ViT_B_32'})
-c.rank(..., parameters={'model': 'ViT_B_32'})
-```
 
 ### Performance tip on large number of Documents
 

--- a/docs/user-guides/client.md
+++ b/docs/user-guides/client.md
@@ -192,6 +192,65 @@ Use `.encode(..., show_progress=True)` to turn on the progress bar.
 Progress bar may not show up in the PyCharm debug terminal. This is an upstream issue of `rich` package.
 ```
 
+### Select model to use
+
+When you are running multiple models in the same Flow, you can override the default `requests` in `clip_server` and select which model to use in `clip_client` by setting `.encode(..., parameters={'model': 'model_name'})` or `.rank(..., parameters={'model': 'model_name'})`.
+
+
+Below is a sample YAML file to run `ViT-B/32`, `ViT-B/16` and `ViT-L/14@336px` models in the same Flow. 
+Note that `ViT-L/14@336px` is set to default if no model is specified.
+Learn more about [setting/overriding default `requests` configuration.](https://docs.jina.ai/fundamentals/flow/add-executors/#set-requests-via-uses-requests)
+
+```yaml
+jtype: Flow
+version: '1'
+with:
+  port: 51000
+  protocol: 'http'
+executors:
+  - name: ViT_B_32
+    replicas: 1
+    uses:
+      jtype: CLIPEncoder
+      with:
+        name: ViT-B/32
+      metas:
+        py_modules:
+          - clip_server.executors.clip_torch
+      requests: {'/encode/ViT-B/32': 'encode', '/': '_dry_run_func'}
+  - name: ViT_B_16
+    replicas: 1
+    uses:
+      jtype: CLIPEncoder
+      with:
+        name: ViT-B/16
+      metas:
+        py_modules:
+          - clip_server.executors.clip_torch
+      requests: { '/encode/ViT-B/16': 'encode', '/': '_dry_run_func' }
+  - name: ViT_L_14_336px
+    replicas: 1
+    uses:
+      jtype: CLIPEncoder
+      with:
+        name: ViT-L/14@336px
+      metas:
+        py_modules:
+          - clip_server.executors.clip_torch
+      requests: {'/encode': 'encode', '/encode/ViT-L/14@336px': 'encode'}
+```
+
+```{tip}
+`_dry_run_func` is a dummy function that does nothing so the first two models do not affect the result when no model is specified and the default one is used.
+```
+
+You can now specify to use `ViT-B/32` model like this:
+
+```python
+c = Client(...)
+c.encode(..., parameters={'model': 'ViT_B_32'})
+c.rank(..., parameters={'model': 'ViT_B_32'})
+```
 
 ### Performance tip on large number of Documents
 


### PR DESCRIPTION
This pr allows the user to select the model in the client when multiple models are running.

Sample usage:

```
from clip_client import Client

c = Client(xxx)
c.encode(xxx, parameters={'model': 'RN50'})
c.rank(xxx, parameters={'model': 'RN50'})
```