### PR TITLE
feat: add warning if input is too large

### DIFF
--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -313,8 +313,8 @@ class Client:
             )
         elif total > 500:
             warnings.warn(
-                'Input size is too large, it is recommended to use smaller input size for better performance. '
-                'Please ensure the inputs are all valid.'
+                'Input size is too large, the process may fail if the input has anything invalid. '
+                'It is recommended to use a smaller input size.'
             )
 
         from docarray.array.mixins.io.pbar import get_pbar

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -109,6 +109,11 @@ class Client:
                 f'content must be an Iterable of [str, Document], try `.encode(["{content}"])` instead'
             )
 
+        if len(content) > 100 * kwargs.get('batch_size', 8):
+            warnings.warn(
+                f'Document size is too large, it is recommended to use smaller document size for better performance'
+            )
+
         self._prepare_streaming(
             not kwargs.get('show_progress'),
             total=len(content) if hasattr(content, '__len__') else None,

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -313,8 +313,7 @@ class Client:
             )
         elif total > 500:
             warnings.warn(
-                'Input size is too large, the process may fail if the input has anything invalid. '
-                'It is recommended to use a smaller input size.'
+                'Please ensure all the inputs are valid, otherwise the request will be aborted.'
             )
 
         from docarray.array.mixins.io.pbar import get_pbar

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -1,6 +1,7 @@
 import mimetypes
 import os
 import time
+import types
 import warnings
 from typing import (
     overload,
@@ -109,7 +110,9 @@ class Client:
                 f'content must be an Iterable of [str, Document], try `.encode(["{content}"])` instead'
             )
 
-        if len(content) > 100 * kwargs.get('batch_size', 8):
+        if not isinstance(content, types.GeneratorType) and len(
+            content
+        ) > 100 * kwargs.get('batch_size', 8):
             warnings.warn(
                 f'Document size is too large, it is recommended to use smaller document size for better performance'
             )

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -110,14 +110,6 @@ class Client:
                 f'content must be an Iterable of [str, Document], try `.encode(["{content}"])` instead'
             )
 
-        if not isinstance(content, types.GeneratorType) and len(
-            content
-        ) > 100 * kwargs.get('batch_size', 8):
-            warnings.warn(
-                f'Document size is too large, it is recommended to use smaller document size for better performance. '
-                'Please ensure the inputs are all valid.'
-            )
-
         self._prepare_streaming(
             not kwargs.get('show_progress'),
             total=len(content) if hasattr(content, '__len__') else None,
@@ -149,7 +141,7 @@ class Client:
     def _unboxed_result(results: 'DocumentArray'):
         if results.embeddings is None:
             raise ValueError(
-                'empty embedding returned from the server. '
+                'Empty embedding returned from the server. '
                 'This often due to a mis-config of the server, '
                 'restarting the server or changing the serving port number often solves the problem'
             )
@@ -317,7 +309,12 @@ class Client:
         if total is None:
             total = 500
             warnings.warn(
-                'the length of the input is unknown, the progressbar would not be accurate.'
+                'The length of the input is unknown, the progressbar would not be accurate.'
+            )
+        elif total > 500:
+            warnings.warn(
+                'Input size is too large, it is recommended to use smaller input size for better performance. '
+                'Please ensure the inputs are all valid.'
             )
 
         from docarray.array.mixins.io.pbar import get_pbar
@@ -344,7 +341,7 @@ class Client:
         elif d.tensor is not None:
             return d
         else:
-            raise TypeError(f'unsupported input type {d!r} {d.content_type}')
+            raise TypeError(f'Unsupported input type {d!r} {d.content_type}')
 
     @staticmethod
     def _prepare_rank_doc(d: 'Document', _source: str = 'matches'):
@@ -368,7 +365,7 @@ class Client:
             if isinstance(c, Document):
                 yield self._prepare_rank_doc(c, _source)
             else:
-                raise TypeError(f'unsupported input type {c!r}')
+                raise TypeError(f'Unsupported input type {c!r}')
 
             if hasattr(self, '_pbar'):
                 self._pbar.update(

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -114,7 +114,8 @@ class Client:
             content
         ) > 100 * kwargs.get('batch_size', 8):
             warnings.warn(
-                f'Document size is too large, it is recommended to use smaller document size for better performance'
+                f'Document size is too large, it is recommended to use smaller document size for better performance. '
+                'Please ensure the inputs are all valid.'
             )
 
         self._prepare_streaming(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,3 +55,13 @@ def test_client_concurrent_requests(port_generator):
 
         for r in results:
             assert len(set([d.id[:2] for d in r])) == 1
+
+
+def test_client_large_input(make_flow, port_generator):
+    from clip_client.client import Client
+
+    inputs = ['hello' for _ in range(1000)]
+
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    with pytest.warns(UserWarning):
+        c.encode(inputs if not callable(inputs) else inputs())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -60,7 +60,7 @@ def test_client_concurrent_requests(port_generator):
 def test_client_large_input(make_flow, port_generator):
     from clip_client.client import Client
 
-    inputs = ['hello' for _ in range(1000)]
+    inputs = ['hello' for _ in range(600)]
 
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     with pytest.warns(UserWarning):


### PR DESCRIPTION
<s>When the doc to be encoded is broken (contains broken URIs, incomplete files, etc.), the server will raise an error and the whole encoding process is thus stopped.
This is especially infeasible for large encoding tasks with thousands or even millions of docs.
In this pr, we improve the user experience by skipping such broken docs and printing warning messages instead.
The whole process is not interrupted.
Users can thus decide whether to proceed with this task or stop.

- [ ] Print warning messages on the server side
- [ ] Print warning messages on the client side when getting incomplete results (i.e. some docs' embeddings are empty)
- [ ] Add test cases</s>

After several discussions with team members, we decide to add a warning at the very beginning of the client to suggest users use moderate-size documents when the input is too large since there is always one more case to consider