### PR TITLE
feat: do not send blob from server when it is loaded in client

### DIFF
--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -308,6 +308,10 @@ class Client:
                     ),
                 )
 
+        for c in content:
+            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
+                c.pop('blob')
+
         return self._unboxed_result(results)
 
     def _prepare_streaming(self, disable, total):
@@ -457,5 +461,8 @@ class Client:
                         )
                     ),
                 )
+
+        for d in docs:
+            self._reset_rank_doc(d, _source=kwargs.get('source', 'matches'))
 
         return results

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -160,7 +160,8 @@ class Client:
                 _mime = mimetypes.guess_type(c)[0]
                 if _mime and _mime.startswith('image'):
                     yield Document(
-                        tags={'__created_by_CAS__': True}, uri=c
+                        tags={'__created_by_CAS__': True, '__loaded_by_CAS__': True},
+                        uri=c,
                     ).load_uri_to_blob()
                 else:
                     yield Document(tags={'__created_by_CAS__': True}, text=c)
@@ -169,6 +170,7 @@ class Client:
                     yield c
                 elif not c.blob and c.uri:
                     c.load_uri_to_blob()
+                    c.tags['__loaded_by_CAS__'] = True
                     yield c
                 elif c.tensor is not None:
                     yield c
@@ -331,6 +333,7 @@ class Client:
             return d
         elif not d.blob and d.uri:
             d.load_uri_to_blob()
+            d.tags['__loaded_by_CAS__'] = True
             return d
         elif d.tensor is not None:
             return d

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -104,8 +104,6 @@ class Client:
         ...
 
     def encode(self, content, **kwargs):
-        from docarray import Document
-
         if isinstance(content, str):
             raise TypeError(
                 f'content must be an Iterable of [str, Document], try `.encode(["{content}"])` instead'
@@ -123,7 +121,7 @@ class Client:
             )
 
         for c in content:
-            if isinstance(c, Document) and c.tags.pop('__loaded_by_CAS__', False):
+            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
         return self._unboxed_result(results)

--- a/server/clip_server/executors/helper.py
+++ b/server/clip_server/executors/helper.py
@@ -37,9 +37,10 @@ def preproc_image(
         tensors_batch.append(preprocess_fn(d.tensor).detach())
 
         # recover doc content
-        d.content = content
         if d.tags.pop('__loaded_by_CAS__', None):
             d.pop('tensor')
+        else:
+            d.content = content
 
     tensors_batch = torch.stack(tensors_batch).type(torch.float32)
 

--- a/server/clip_server/executors/helper.py
+++ b/server/clip_server/executors/helper.py
@@ -37,7 +37,7 @@ def preproc_image(
         tensors_batch.append(preprocess_fn(d.tensor).detach())
 
         # recover doc content
-        if d.tags.pop('__loaded_by_CAS__', None):
+        if d.tags.pop('__loaded_by_CAS__', False):
             d.pop('tensor')
         else:
             d.content = content

--- a/server/clip_server/executors/helper.py
+++ b/server/clip_server/executors/helper.py
@@ -38,6 +38,8 @@ def preproc_image(
 
         # recover doc content
         d.content = content
+        if d.content.tags.pop('__loaded_by_CAS__'):
+            d.blob = None
 
     tensors_batch = torch.stack(tensors_batch).type(torch.float32)
 

--- a/server/clip_server/executors/helper.py
+++ b/server/clip_server/executors/helper.py
@@ -38,7 +38,7 @@ def preproc_image(
 
         # recover doc content
         d.content = content
-        if d.tags.pop('__loaded_by_CAS__'):
+        if d.tags.pop('__loaded_by_CAS__', None):
             d.pop('tensor')
 
     tensors_batch = torch.stack(tensors_batch).type(torch.float32)

--- a/server/clip_server/executors/helper.py
+++ b/server/clip_server/executors/helper.py
@@ -38,8 +38,8 @@ def preproc_image(
 
         # recover doc content
         d.content = content
-        if d.content.tags.pop('__loaded_by_CAS__'):
-            d.blob = None
+        if d.tags.pop('__loaded_by_CAS__'):
+            d.pop('tensor')
 
     tensors_batch = torch.stack(tensors_batch).type(torch.float32)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def port_generator():
     return random_port
 
 
-@pytest.fixture(scope='session', params=['onnx'])
+@pytest.fixture(scope='session', params=['onnx', 'torch', 'onnx_custom'])
 def make_flow(port_generator, request):
     if request.param != 'onnx_custom':
         if request.param == 'onnx':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def port_generator():
     return random_port
 
 
-@pytest.fixture(scope='session', params=['onnx', 'torch', 'onnx_custom'])
+@pytest.fixture(scope='session', params=['onnx'])
 def make_flow(port_generator, request):
     if request.param != 'onnx_custom':
         if request.param == 'onnx':

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,8 +1,9 @@
 import asyncio
-
+import os
 import pytest
 
 from clip_client import Client
+from docarray import Document, DocumentArray
 
 
 async def another_heavylifting_job():
@@ -16,3 +17,37 @@ async def test_async_encode(make_flow):
     t2 = asyncio.create_task(c.aencode(['hello world'] * 10))
     await asyncio.gather(t1, t2)
     assert t2.result().shape
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        DocumentArray([Document(text='hello, world'), Document(text='goodbye, world')]),
+        DocumentArray(
+            [
+                Document(
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    text='hello, world',
+                ),
+            ]
+        ),
+        DocumentArray.from_files(
+            f'{os.path.dirname(os.path.abspath(__file__))}/**/*.jpg'
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_docarray_preserve_original_inputs(
+    make_flow, inputs, port_generator
+):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    t1 = asyncio.create_task(another_heavylifting_job())
+    t2 = asyncio.create_task(c.aencode(inputs if not callable(inputs) else inputs()))
+    await asyncio.gather(t1, t2)
+    assert isinstance(t2.result(), DocumentArray)
+    assert t2.result().embeddings.shape
+    assert t2.result().contents == inputs.contents
+    assert '__created_by_CAS__' not in t2.result()[0].tags
+    assert '__loaded_by_CAS__' not in t2.result()[0].tags
+    assert not t2.result()[0].tensor
+    assert not t2.result()[0].blob

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -91,6 +91,8 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 def test_docarray_inputs(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.rank([d])
+    assert r[0].content == d.content
+    assert r[0].matches.contents == d.matches.contents
     assert '__loaded_by_CAS__' not in d.tags
     assert not d.blob
     assert not d.tensor
@@ -130,6 +132,8 @@ async def test_async_arank(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = await c.arank([d])
     assert isinstance(r, DocumentArray)
+    assert r[0].content == d.content
+    assert r[0].matches.contents == d.matches.contents
     rv = r['@m', 'scores__clip_score__value']
     for v in rv:
         assert v is not None

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -30,8 +30,10 @@ async def test_torch_executor_rank_img2texts(encoder_class):
     for d in da:
         for c in d.matches:
             assert c.scores['clip_score'].value is not None
+            assert '__loaded_by_CAS__' not in c.tags
         org_score = d.matches[:, 'scores__clip_score__value']
         assert org_score == list(sorted(org_score, reverse=True))
+        assert '__loaded_by_CAS__' not in d.tags
 
 
 @pytest.mark.asyncio
@@ -53,9 +55,11 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
         for c in d.matches:
             assert c.scores['clip_score'].value is not None
             assert c.scores['clip_score_cosine'].value is not None
+            assert '__loaded_by_CAS__' not in c.tags
         np.testing.assert_almost_equal(
             sum(c.scores['clip_score'].value for c in d.matches), 1
         )
+        assert '__loaded_by_CAS__' not in d.tags
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -91,6 +91,12 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 def test_docarray_inputs(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.rank([d])
+    assert '__loaded_by_CAS__' not in d.tags
+    assert not d.blob
+    assert not d.tensor
+    assert '__loaded_by_CAS__' not in d.matches[0].tags
+    assert not d.matches[0].blob
+    assert not d.matches[0].tensor
     assert isinstance(r, DocumentArray)
     rv1 = r['@m', 'scores__clip_score__value']
     rv2 = r['@m', 'scores__clip_score_cosine__value']

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -31,9 +31,13 @@ async def test_torch_executor_rank_img2texts(encoder_class):
         for c in d.matches:
             assert c.scores['clip_score'].value is not None
             assert '__loaded_by_CAS__' not in c.tags
+            assert not c.tensor
+            assert not c.blob
         org_score = d.matches[:, 'scores__clip_score__value']
         assert org_score == list(sorted(org_score, reverse=True))
         assert '__loaded_by_CAS__' not in d.tags
+        assert not d.tensor
+        assert not d.blob
 
 
 @pytest.mark.asyncio
@@ -56,10 +60,14 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
             assert c.scores['clip_score'].value is not None
             assert c.scores['clip_score_cosine'].value is not None
             assert '__loaded_by_CAS__' not in c.tags
+            assert not c.tensor
+            assert not c.blob
         np.testing.assert_almost_equal(
             sum(c.scores['clip_score'].value for c in d.matches), 1
         )
         assert '__loaded_by_CAS__' not in d.tags
+        assert not d.tensor
+        assert not d.blob
 
 
 @pytest.mark.parametrize(

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -108,6 +108,8 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
     assert r.contents == inputs.contents
     assert '__created_by_CAS__' not in r[0].tags
     assert '__loaded_by_CAS__' not in r[0].tags
+    assert not r[0].tensor
+    assert not r[0].blob
 
 
 @pytest.mark.parametrize(

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -79,6 +79,8 @@ def test_docarray_inputs(make_flow, inputs, port_generator):
     assert r.embeddings.shape
     assert '__created_by_CAS__' not in r[0].tags
     assert '__loaded_by_CAS__' not in r[0].tags
+    assert not r[0].tensor
+    assert not r[0].blob
 
 
 @pytest.mark.parametrize(
@@ -137,6 +139,14 @@ def test_docarray_traversal(make_flow, inputs, port_generator):
     assert r1[0].chunks.embeddings.shape[0] == len(inputs)
     assert '__created_by_CAS__' not in r1[0].tags
     assert '__loaded_by_CAS__' not in r1[0].tags
+    assert not r1[0].tensor
+    assert not r1[0].blob
+    assert not r1[0].chunks[0].tensor
+    assert not r1[0].chunks[0].blob
     assert r2[0].chunks.embeddings.shape[0] == len(inputs)
     assert '__created_by_CAS__' not in r2[0].tags
     assert '__loaded_by_CAS__' not in r2[0].tags
+    assert not r2[0].tensor
+    assert not r2[0].blob
+    assert not r2[0].chunks[0].tensor
+    assert not r2[0].chunks[0].blob

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -78,6 +78,7 @@ def test_docarray_inputs(make_flow, inputs, port_generator):
     assert isinstance(r, DocumentArray)
     assert r.embeddings.shape
     assert '__created_by_CAS__' not in r[0].tags
+    assert '__loaded_by_CAS__' not in r[0].tags
 
 
 @pytest.mark.parametrize(
@@ -104,6 +105,7 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
     assert r.embeddings.shape
     assert r.contents == inputs.contents
     assert '__created_by_CAS__' not in r[0].tags
+    assert '__loaded_by_CAS__' not in r[0].tags
 
 
 @pytest.mark.parametrize(
@@ -134,5 +136,7 @@ def test_docarray_traversal(make_flow, inputs, port_generator):
     r2 = c.post(on='/', inputs=da, parameters={'access_paths': '@c'})
     assert r1[0].chunks.embeddings.shape[0] == len(inputs)
     assert '__created_by_CAS__' not in r1[0].tags
+    assert '__loaded_by_CAS__' not in r1[0].tags
     assert r2[0].chunks.embeddings.shape[0] == len(inputs)
     assert '__created_by_CAS__' not in r2[0].tags
+    assert '__loaded_by_CAS__' not in r2[0].tags


### PR DESCRIPTION
If the user encodes a document with uri and no blob, the current implementation will load the blob in the client and send it to the server.
This pr saves the bandwidth by not sending back blob from the server


I ran some tests to see the benefit we have from this change.


```{python}
from clip_client import Client
from jina import Document, DocumentArray

c = Client('grpc://0.0.0.0:5001')

def data_gen():
    for _ in range(80):
        yield Document(uri='toy.png')

r = c.encode(data_gen(), batch_size=8, show_progress=True)
r.summary()
```

- Server config: default minibatch_size=32, model: Vit-L/14@336px, replicas: 3

- Client config: default batch_size=8, input DocumentArray size=80 with each Document having a URI of an image of size ~1.5MB

- Before: send 90MB, recv 90MB, cost 3-13min (Server hosted on Beijing GPU 3-7min/Berlin GPU 6-13min)

- After: send 90MB, recv 250KB, cost 1-3min

In general, the time varies because of remote network communications, but the recv package sizes substantially drops