### PR TITLE
feat: allow custom on_done callback function in encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install wheel pytest pytest-cov
           pip install --no-cache-dir "client/[test]"
-          pip install --no-cache-dir "server/[onnx]"
+          pip install --no-cache-dir --upgrade "server/[onnx]"
           pip install --no-cache-dir "server/[transformers]"
       - name: Test
         id: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install wheel pytest pytest-cov
           pip install --no-cache-dir "client/[test]"
-          pip install --no-cache-dir --upgrade "server/[onnx]"
+          pip install --no-cache-dir "server/[onnx]"
+          pip install -U protobuf
           pip install --no-cache-dir "server/[transformers]"
       - name: Test
         id: test

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -138,7 +138,10 @@ class Client:
         return self._unboxed_result(results)
 
     def _gather_result(
-        self, response, results: 'DocumentArray', callback: Optional[types.FunctionType]
+        self,
+        response,
+        results: 'DocumentArray',
+        callback: Optional[types.FunctionType] = None,
     ):
         from rich import filesize
 

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -155,7 +155,7 @@ class Client:
         )
 
         if callback:
-            callback(r)
+            callback(response)
         else:
             results.extend(r)
 


### PR DESCRIPTION
This pr allows users to pass a custom on_done callback function in encoding.
If none is provided, it will use the default gather_result callback function and extend the results docarray as usual.

The original gather_result is kept as a callback wrapper to update the progress bar