### PR TITLE
feat: in-place result in clip_client; preserve output order by uid

### DIFF
--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -126,7 +126,7 @@ class Client:
             self._client.post(
                 on=f'/encode/{model_name}'.rstrip('/'),
                 **self._get_post_payload(content, results, kwargs),
-                on_done=partial(self._gather_result, results=results),
+                on_done=partial(self._gather_encode_result, results=results),
                 parameters=parameters,
             )
 
@@ -137,8 +137,7 @@ class Client:
         _unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, _unbox)
 
-
-    def _gather_result(self, response, results: 'DocumentArray'):
+    def _gather_encode_result(self, response, results: 'DocumentArray'):
         from rich import filesize
 
         r = response.data.docs
@@ -459,7 +458,7 @@ class Client:
         """
         self._prepare_streaming(
             not kwargs.get('show_progress'),
-            total=len(docs),
+            total=len(docs) if hasattr(docs, '__len__') else None,
         )
         results = DocumentArray()
         with self._pbar:
@@ -481,7 +480,7 @@ class Client:
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),
-            total=len(docs),
+            total=len(docs) if hasattr(docs, '__len__') else None,
         )
         results = DocumentArray()
         with self._pbar:
@@ -511,6 +510,7 @@ class Client:
 
         return results
 
+    def _gather_rank_result(self, response, docs_copy: 'DocumentArray'):
     @overload
     def index(
         self,

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -463,6 +463,7 @@ class Client:
             not kwargs.get('show_progress'),
             total=len(docs) if hasattr(docs, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', None)
@@ -488,6 +489,7 @@ class Client:
             not kwargs.get('show_progress'),
             total=len(docs) if hasattr(docs, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', None)

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -144,7 +144,7 @@ class Client:
         )
 
     def _gather_result(
-        self, response, results: 'DocumentArray', attribute: Optional[str] = ''
+        self, response, results: 'DocumentArray', attribute: Optional[str] = None
     ):
         from rich import filesize
 
@@ -171,7 +171,7 @@ class Client:
         if hasattr(self, '_pbar'):
             self._pbar.start_task(self._s_task)
 
-        for i, c in enumerate(content):
+        for c in content:
             if isinstance(c, str):
                 _mime = mimetypes.guess_type(c)[0]
                 if _mime and _mime.startswith('image'):
@@ -299,9 +299,9 @@ class Client:
                 parameters=parameters,
             )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, unbox)
@@ -367,9 +367,9 @@ class Client:
                     ),
                 )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, unbox)
@@ -383,7 +383,7 @@ class Client:
         if hasattr(self, '_pbar'):
             self._pbar.start_task(self._s_task)
 
-        for i, c in enumerate(content):
+        for c in content:
             if isinstance(c, Document):
                 d = self._prepare_rank_doc(c, source)
             else:
@@ -443,15 +443,21 @@ class Client:
     def _reset_rank_doc(d: 'Document', _source: str = 'matches'):
         _get = lambda d: getattr(d, _source)
 
+        print(123123)
         if d.tags.pop('__loaded_by_CAS__', False):
+            print(111)
             d.pop('blob')
+        else:
+            print(222)
 
         for c in _get(d):
             if c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
         return d
 
-    def rank(self, docs: Iterable['Document'], **kwargs) -> 'DocumentArray':
+    def rank(
+        self, docs: Union['DocumentArray', Iterable['Document']], **kwargs
+    ) -> 'DocumentArray':
         """Rank image-text matches according to the server CLIP model.
         Given a Document with nested matches, where the root is image/text and the matches is in another modality, i.e.
         text/image; this method ranks the matches according to the CLIP model.
@@ -480,8 +486,9 @@ class Client:
                 ),
                 parameters=parameters,
             )
-        for d in docs:
-            self._reset_rank_doc(d, _source=kwargs.get('source', 'matches'))
+
+        for r in results:
+            self._reset_rank_doc(r, _source=kwargs.get('source', 'matches'))
 
         return results
 
@@ -519,8 +526,8 @@ class Client:
                     ),
                 )
 
-        for d in docs:
-            self._reset_rank_doc(d, _source=kwargs.get('source', 'matches'))
+        for r in results:
+            self._reset_rank_doc(r, _source=kwargs.get('source', 'matches'))
 
         return results
 
@@ -589,9 +596,9 @@ class Client:
                 parameters=parameters,
             )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         return results
 
@@ -650,9 +657,9 @@ class Client:
                     ),
                 )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         return results
 
@@ -726,9 +733,9 @@ class Client:
                 ),
             )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         return results
 
@@ -793,8 +800,8 @@ class Client:
                     ),
                 )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         return results

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -313,6 +313,7 @@ class Client:
         *,
         batch_size: Optional[int] = None,
         show_progress: bool = False,
+        parameters: Optional[dict] = None,
     ) -> 'np.ndarray':
         ...
 
@@ -323,6 +324,7 @@ class Client:
         *,
         batch_size: Optional[int] = None,
         show_progress: bool = False,
+        parameters: Optional[dict] = None,
     ) -> 'DocumentArray':
         ...
 

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -118,6 +118,7 @@ class Client:
             not kwargs.get('show_progress'),
             total=len(content) if hasattr(content, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', None)

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -492,7 +492,9 @@ class Client:
 
         return results
 
-    async def arank(self, docs: Iterable['Document'], **kwargs) -> 'DocumentArray':
+    async def arank(
+        self, docs: Union['DocumentArray', Iterable['Document']], **kwargs
+    ) -> 'DocumentArray':
         from rich import filesize
 
         if hasattr(docs, '__len__') and len(docs) == 0:

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -443,12 +443,8 @@ class Client:
     def _reset_rank_doc(d: 'Document', _source: str = 'matches'):
         _get = lambda d: getattr(d, _source)
 
-        print(123123)
         if d.tags.pop('__loaded_by_CAS__', False):
-            print(111)
             d.pop('blob')
-        else:
-            print(222)
 
         for c in _get(d):
             if c.tags.pop('__loaded_by_CAS__', False):
@@ -466,6 +462,8 @@ class Client:
         :param docs: the input Documents
         :return: the ranked Documents in a DocumentArray.
         """
+        if isinstance(docs, str):
+            raise TypeError(f'Content must be an Iterable of [Document]')
         if hasattr(docs, '__len__') and len(docs) == 0:
             return DocumentArray() if isinstance(docs, DocumentArray) else []
 
@@ -497,6 +495,8 @@ class Client:
     ) -> 'DocumentArray':
         from rich import filesize
 
+        if isinstance(docs, str):
+            raise TypeError(f'Content must be an Iterable of [Document]')
         if hasattr(docs, '__len__') and len(docs) == 0:
             return DocumentArray() if isinstance(docs, DocumentArray) else []
 

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -1,7 +1,6 @@
 import mimetypes
 import os
 import time
-import types
 import warnings
 from typing import (
     overload,

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -333,7 +333,7 @@ class Client:
 
         if isinstance(content, str):
             raise TypeError(
-                f'Content must be an Iterable of [str, Document], try `.encode(["{content}"])` instead'
+                f'Content must be an Iterable of [str, Document], try `.aencode(["{content}"])` instead'
             )
         if hasattr(content, '__len__') and len(content) == 0:
             return DocumentArray() if isinstance(content, DocumentArray) else []
@@ -593,7 +593,7 @@ class Client:
             if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
-        return self._unboxed_result(results)
+        return results
 
     @overload
     async def aindex(
@@ -619,6 +619,11 @@ class Client:
 
     async def aindex(self, content, **kwargs):
         from rich import filesize
+
+        if isinstance(content, str):
+            raise TypeError(
+                f'content must be an Iterable of [str, Document], try `.aindex(["{content}"])` instead'
+            )
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),
@@ -649,7 +654,7 @@ class Client:
             if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
-        return self._unboxed_result(results)
+        return results
 
     @overload
     def search(
@@ -753,6 +758,11 @@ class Client:
 
     async def asearch(self, content, limit: int = 10, **kwargs):
         from rich import filesize
+
+        if isinstance(content, str):
+            raise TypeError(
+                f'content must be an Iterable of [str, Document], try `.asearch(["{content}"])` instead'
+            )
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -133,8 +133,9 @@ class Client:
             if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
-        _unbox = isinstance(content, list) and isinstance(content[0], str)
+        _unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, _unbox)
+
 
     def _gather_result(self, response, results: 'DocumentArray'):
         from rich import filesize
@@ -313,7 +314,6 @@ class Client:
             total=len(content) if hasattr(content, '__len__') else None,
         )
 
-
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', None)
@@ -342,7 +342,7 @@ class Client:
             if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
-        _unbox = isinstance(content, list) and isinstance(content[0], str)
+        _unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, _unbox)
 
     def _prepare_streaming(self, disable, total):

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -45,6 +45,7 @@ async def test_async_docarray_preserve_original_inputs(
     t2 = asyncio.create_task(c.aencode(inputs if not callable(inputs) else inputs()))
     await asyncio.gather(t1, t2)
     assert isinstance(t2.result(), DocumentArray)
+    assert inputs[0] is t2.result()[0]
     assert t2.result().embeddings.shape
     assert t2.result().contents == inputs.contents
     assert '__created_by_CAS__' not in t2.result()[0].tags

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -37,9 +37,7 @@ async def test_async_encode(make_flow):
     ],
 )
 @pytest.mark.asyncio
-async def test_async_docarray_preserve_original_inputs(
-    make_flow, inputs, port_generator
-):
+async def test_async_docarray_preserve_original_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     t1 = asyncio.create_task(another_heavylifting_job())
     t2 = asyncio.create_task(c.aencode(inputs if not callable(inputs) else inputs()))
@@ -52,3 +50,23 @@ async def test_async_docarray_preserve_original_inputs(
     assert not t2.result()[0].tensor
     assert not t2.result()[0].blob
     assert inputs[0] is t2.result()[0]
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [Document(text='hello, world') for _ in range(20)],
+        DocumentArray([Document(text='hello, world') for _ in range(20)]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_docarray_preserve_original_order(make_flow, inputs):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    t1 = asyncio.create_task(another_heavylifting_job())
+    t2 = asyncio.create_task(
+        c.aencode(inputs if not callable(inputs) else inputs(), batch_size=1)
+    )
+    await asyncio.gather(t1, t2)
+    assert isinstance(t2.result(), DocumentArray)
+    for i in range(len(inputs)):
+        assert inputs[i] is t2.result()[i]

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -55,8 +55,8 @@ async def test_async_docarray_preserve_original_inputs(make_flow, inputs):
 @pytest.mark.parametrize(
     'inputs',
     [
-        [Document(text='hello, world') for _ in range(20)],
-        DocumentArray([Document(text='hello, world') for _ in range(20)]),
+        [Document(id=str(i), text='hello, world') for i in range(20)],
+        DocumentArray([Document(id=str(i), text='hello, world') for i in range(20)]),
     ],
 )
 @pytest.mark.asyncio
@@ -70,3 +70,4 @@ async def test_async_docarray_preserve_original_order(make_flow, inputs):
     assert isinstance(t2.result(), DocumentArray)
     for i in range(len(inputs)):
         assert inputs[i] is t2.result()[i]
+        assert inputs[i].id == str(i)

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -45,10 +45,10 @@ async def test_async_docarray_preserve_original_inputs(
     t2 = asyncio.create_task(c.aencode(inputs if not callable(inputs) else inputs()))
     await asyncio.gather(t1, t2)
     assert isinstance(t2.result(), DocumentArray)
-    assert inputs[0] is t2.result()[0]
     assert t2.result().embeddings.shape
     assert t2.result().contents == inputs.contents
     assert '__created_by_CAS__' not in t2.result()[0].tags
     assert '__loaded_by_CAS__' not in t2.result()[0].tags
     assert not t2.result()[0].tensor
     assert not t2.result()[0].blob
+    assert inputs[0] is t2.result()[0]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,3 +107,27 @@ async def test_client_empty_input(make_flow, inputs):
     else:
         assert isinstance(r, list)
     assert len(r) == 0
+
+
+@pytest.mark.asyncio
+async def test_str_input(make_torch_flow):
+    from clip_client.client import Client
+
+    c = Client(server=f'grpc://0.0.0.0:{make_torch_flow.port}')
+
+    with pytest.raises(Exception):
+        c.encode('hello')
+    with pytest.raises(Exception):
+        await c.aencode('hello')
+    with pytest.raises(Exception):
+        c.rank('hello')
+    with pytest.raises(Exception):
+        await c.arank('hello')
+    with pytest.raises(Exception):
+        c.index('hello')
+    with pytest.raises(Exception):
+        await c.aindex('hello')
+    with pytest.raises(Exception):
+        c.search('hello')
+    with pytest.raises(Exception):
+        await c.asearch('hello')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -79,11 +79,31 @@ async def test_client_empty_input(make_flow, inputs):
     from clip_client.client import Client
 
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
-    with pytest.raises(Exception):
-        c.encode(inputs if not callable(inputs) else inputs())
-    with pytest.raises(Exception):
-        await c.aencode(inputs if not callable(inputs) else inputs())
-    with pytest.raises(Exception):
-        c.rank(inputs if not callable(inputs) else inputs())
-    with pytest.raises(Exception):
-        await c.arank(inputs if not callable(inputs) else inputs())
+
+    r = c.encode(inputs if not callable(inputs) else inputs())
+    if isinstance(inputs, DocumentArray):
+        assert isinstance(r, DocumentArray)
+    else:
+        assert isinstance(r, list)
+    assert len(r) == 0
+
+    r = await c.aencode(inputs if not callable(inputs) else inputs())
+    if isinstance(inputs, DocumentArray):
+        assert isinstance(r, DocumentArray)
+    else:
+        assert isinstance(r, list)
+    assert len(r) == 0
+
+    r = c.rank(inputs if not callable(inputs) else inputs())
+    if isinstance(inputs, DocumentArray):
+        assert isinstance(r, DocumentArray)
+    else:
+        assert isinstance(r, list)
+    assert len(r) == 0
+
+    r = await c.arank(inputs if not callable(inputs) else inputs())
+    if isinstance(inputs, DocumentArray):
+        assert isinstance(r, DocumentArray)
+    else:
+        assert isinstance(r, list)
+    assert len(r) == 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,9 +74,16 @@ def test_client_large_input(make_flow):
         DocumentArray([]),
     ],
 )
-def test_client_empty_input(make_flow, inputs):
+@pytest.mark.asyncio
+async def test_client_empty_input(make_flow, inputs):
     from clip_client.client import Client
 
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     with pytest.raises(Exception):
         c.encode(inputs if not callable(inputs) else inputs())
+    with pytest.raises(Exception):
+        await c.aencode(inputs if not callable(inputs) else inputs())
+    with pytest.raises(Exception):
+        c.rank(inputs if not callable(inputs) else inputs())
+    with pytest.raises(Exception):
+        await c.arank(inputs if not callable(inputs) else inputs())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,12 +57,12 @@ def test_client_concurrent_requests(port_generator):
             assert len(set([d.id[:2] for d in r])) == 1
 
 
-def test_client_large_input(make_flow):
+def test_client_large_input(make_torch_flow):
     from clip_client.client import Client
 
     inputs = ['hello' for _ in range(600)]
 
-    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    c = Client(server=f'grpc://0.0.0.0:{make_torch_flow.port}')
     with pytest.warns(UserWarning):
         c.encode(inputs if not callable(inputs) else inputs())
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,7 +23,7 @@ class Exec2(Executor):
 
     @requests
     async def process(self, docs, **kwargs):
-        results = await self._client.aencode(docs, request_size=2)
+        results = await self._client.aencode(docs, batch_size=2)
         return results
 
 
@@ -75,10 +75,10 @@ def test_client_large_input(make_torch_flow):
     ],
 )
 @pytest.mark.asyncio
-async def test_client_empty_input(make_flow, inputs):
+async def test_client_empty_input(make_torch_flow, inputs):
     from clip_client.client import Client
 
-    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    c = Client(server=f'grpc://0.0.0.0:{make_torch_flow.port}')
 
     r = c.encode(inputs if not callable(inputs) else inputs())
     if isinstance(inputs, DocumentArray):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -65,3 +65,18 @@ def test_client_large_input(make_flow, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     with pytest.warns(UserWarning):
         c.encode(inputs if not callable(inputs) else inputs())
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [],
+        DocumentArray([]),
+    ],
+)
+def test_client_empty_input(make_flow, inputs, port_generator):
+    from clip_client.client import Client
+
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    with pytest.raises(Exception):
+        c.encode(inputs if not callable(inputs) else inputs())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,7 +57,7 @@ def test_client_concurrent_requests(port_generator):
             assert len(set([d.id[:2] for d in r])) == 1
 
 
-def test_client_large_input(make_flow, port_generator):
+def test_client_large_input(make_flow):
     from clip_client.client import Client
 
     inputs = ['hello' for _ in range(600)]
@@ -74,7 +74,7 @@ def test_client_large_input(make_flow, port_generator):
         DocumentArray([]),
     ],
 )
-def test_client_empty_input(make_flow, inputs, port_generator):
+def test_client_empty_input(make_flow, inputs):
     from clip_client.client import Client
 
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,7 +110,7 @@ async def test_client_empty_input(make_torch_flow, inputs):
 
 
 @pytest.mark.asyncio
-async def test_str_input(make_torch_flow):
+async def test_wrong_input_type(make_torch_flow):
     from clip_client.client import Client
 
     c = Client(server=f'grpc://0.0.0.0:{make_torch_flow.port}')

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -91,7 +91,6 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 def test_docarray_inputs(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.rank([d])
-    assert d is r[0]
     assert r[0].content == d.content
     assert r[0].matches.contents == d.matches.contents
     assert '__loaded_by_CAS__' not in d.tags
@@ -101,6 +100,7 @@ def test_docarray_inputs(make_flow, d):
     assert not d.matches[0].blob
     assert not d.matches[0].tensor
     assert isinstance(r, DocumentArray)
+    assert d is r[0]
     rv1 = r['@m', 'scores__clip_score__value']
     rv2 = r['@m', 'scores__clip_score_cosine__value']
     for v1, v2 in zip(rv1, rv2):
@@ -133,9 +133,9 @@ async def test_async_arank(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = await c.arank([d])
     assert isinstance(r, DocumentArray)
-    assert d is r[0]
     assert r[0].content == d.content
     assert r[0].matches.contents == d.matches.contents
+    assert d is r[0]
     rv = r['@m', 'scores__clip_score__value']
     for v in rv:
         assert v is not None

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -91,6 +91,7 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 def test_docarray_inputs(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.rank([d])
+    assert d is r[0]
     assert r[0].content == d.content
     assert r[0].matches.contents == d.matches.contents
     assert '__loaded_by_CAS__' not in d.tags
@@ -132,6 +133,7 @@ async def test_async_arank(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = await c.arank([d])
     assert isinstance(r, DocumentArray)
+    assert d is r[0]
     assert r[0].content == d.content
     assert r[0].matches.contents == d.matches.contents
     rv = r['@m', 'scores__clip_score__value']

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -213,7 +213,7 @@ def test_docarray_inputs(make_flow, inputs):
 @pytest.mark.asyncio
 async def test_async_arank(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
-    r = await c.arank(inputs)
+    r = await c.arank(inputs if not callable(inputs) else inputs())
     assert '__loaded_by_CAS__' not in r[0].tags
     assert not r[0].blob
     assert not r[0].tensor

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -146,3 +146,50 @@ async def test_async_arank(make_flow, d):
     for v in rv:
         assert v is not None
         assert -1.0 <= v <= 1.0
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [
+            Document(text='A', matches=[Document(text='B'), Document(text='C')])
+            for _ in range(20)
+        ],
+        DocumentArray(
+            [
+                Document(text='A', matches=[Document(text='B'), Document(text='C')])
+                for _ in range(20)
+            ]
+        ),
+    ],
+)
+def test_docarray_preserve_original_order(make_flow, inputs):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    r = c.rank(inputs, batch_size=1)
+    assert isinstance(r, DocumentArray)
+    for i in range(len(inputs)):
+        assert inputs[i] is r[i]
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [
+            Document(text='A', matches=[Document(text='B'), Document(text='C')])
+            for _ in range(20)
+        ],
+        DocumentArray(
+            [
+                Document(text='A', matches=[Document(text='B'), Document(text='C')])
+                for _ in range(20)
+            ]
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_docarray_preserve_original_order(make_flow, inputs):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    r = await c.arank(inputs, batch_size=1)
+    assert isinstance(r, DocumentArray)
+    for i in range(len(inputs)):
+        assert inputs[i] is r[i]

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -71,36 +71,74 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 
 
 @pytest.mark.parametrize(
-    'd',
+    'inputs',
     [
-        Document(
-            uri='https://docarray.jina.ai/_static/favicon.png',
-            matches=[Document(text='hello, world'), Document(text='goodbye, world')],
-        ),
-        Document(
-            text='hello, world',
-            matches=[
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+        [
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            ),
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            ),
+        ],
+        DocumentArray(
+            [
                 Document(
-                    uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    matches=[
+                        Document(text='hello, world'),
+                        Document(text='goodbye, world'),
+                    ],
                 ),
-            ],
+                Document(
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    matches=[
+                        Document(text='hello, world'),
+                        Document(text='goodbye, world'),
+                    ],
+                ),
+            ]
+        ),
+        lambda: (
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            )
+            for _ in range(10)
+        ),
+        DocumentArray(
+            [
+                Document(
+                    text='hello, world',
+                    matches=[
+                        Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                        Document(
+                            uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
+                        ),
+                    ],
+                )
+            ]
         ),
     ],
 )
-def test_docarray_inputs(make_flow, d):
+def test_docarray_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
-    r = c.rank([d])
-    assert r[0].content == d.content
-    assert r[0].matches.contents == d.matches.contents
-    assert '__loaded_by_CAS__' not in d.tags
-    assert not d.blob
-    assert not d.tensor
-    assert '__loaded_by_CAS__' not in d.matches[0].tags
-    assert not d.matches[0].blob
-    assert not d.matches[0].tensor
+    r = c.rank(inputs if not callable(inputs) else inputs())
+    assert '__loaded_by_CAS__' not in r[0].tags
+    assert not r[0].blob
+    assert not r[0].tensor
     assert isinstance(r, DocumentArray)
-    assert d is r[0]
     rv1 = r['@m', 'scores__clip_score__value']
     rv2 = r['@m', 'scores__clip_score_cosine__value']
     for v1, v2 in zip(rv1, rv2):
@@ -111,31 +149,75 @@ def test_docarray_inputs(make_flow, d):
 
 
 @pytest.mark.parametrize(
-    'd',
+    'inputs',
     [
-        Document(
-            uri='https://docarray.jina.ai/_static/favicon.png',
-            matches=[Document(text='hello, world'), Document(text='goodbye, world')],
-        ),
-        Document(
-            text='hello, world',
-            matches=[
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+        [
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            ),
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            ),
+        ],
+        DocumentArray(
+            [
                 Document(
-                    uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    matches=[
+                        Document(text='hello, world'),
+                        Document(text='goodbye, world'),
+                    ],
                 ),
-            ],
+                Document(
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    matches=[
+                        Document(text='hello, world'),
+                        Document(text='goodbye, world'),
+                    ],
+                ),
+            ]
+        ),
+        lambda: (
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            )
+            for _ in range(10)
+        ),
+        DocumentArray(
+            [
+                Document(
+                    text='hello, world',
+                    matches=[
+                        Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                        Document(
+                            uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
+                        ),
+                    ],
+                )
+            ]
         ),
     ],
 )
 @pytest.mark.asyncio
-async def test_async_arank(make_flow, d):
+async def test_async_arank(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
-    r = await c.arank([d])
+    r = await c.arank(inputs)
+    assert '__loaded_by_CAS__' not in r[0].tags
+    assert not r[0].blob
+    assert not r[0].tensor
     assert isinstance(r, DocumentArray)
-    assert r[0].content == d.content
-    assert r[0].matches.contents == d.matches.contents
-    assert d is r[0]
     rv = r['@m', 'scores__clip_score__value']
     for v in rv:
         assert v is not None

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -152,13 +152,19 @@ async def test_async_arank(make_flow, d):
     'inputs',
     [
         [
-            Document(text='A', matches=[Document(text='B'), Document(text='C')])
-            for _ in range(20)
+            Document(
+                id=str(i), text='A', matches=[Document(text='B'), Document(text='C')]
+            )
+            for i in range(20)
         ],
         DocumentArray(
             [
-                Document(text='A', matches=[Document(text='B'), Document(text='C')])
-                for _ in range(20)
+                Document(
+                    id=str(i),
+                    text='A',
+                    matches=[Document(text='B'), Document(text='C')],
+                )
+                for i in range(20)
             ]
         ),
     ],
@@ -169,19 +175,26 @@ def test_docarray_preserve_original_order(make_flow, inputs):
     assert isinstance(r, DocumentArray)
     for i in range(len(inputs)):
         assert inputs[i] is r[i]
+        assert inputs[i].id == str(i)
 
 
 @pytest.mark.parametrize(
     'inputs',
     [
         [
-            Document(text='A', matches=[Document(text='B'), Document(text='C')])
-            for _ in range(20)
+            Document(
+                id=str(i), text='A', matches=[Document(text='B'), Document(text='C')]
+            )
+            for i in range(20)
         ],
         DocumentArray(
             [
-                Document(text='A', matches=[Document(text='B'), Document(text='C')])
-                for _ in range(20)
+                Document(
+                    id=str(i),
+                    text='A',
+                    matches=[Document(text='B'), Document(text='C')],
+                )
+                for i in range(20)
             ]
         ),
     ],
@@ -193,3 +206,4 @@ async def test_async_docarray_preserve_original_order(make_flow, inputs):
     assert isinstance(r, DocumentArray)
     for i in range(len(inputs)):
         assert inputs[i] is r[i]
+        assert inputs[i].id == str(i)

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -159,23 +159,9 @@ def test_docarray_inputs(make_flow, inputs):
                     Document(text='goodbye, world'),
                 ],
             ),
-            Document(
-                uri='https://docarray.jina.ai/_static/favicon.png',
-                matches=[
-                    Document(text='hello, world'),
-                    Document(text='goodbye, world'),
-                ],
-            ),
         ],
         DocumentArray(
             [
-                Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
-                    matches=[
-                        Document(text='hello, world'),
-                        Document(text='goodbye, world'),
-                    ],
-                ),
                 Document(
                     uri='https://docarray.jina.ai/_static/favicon.png',
                     matches=[
@@ -193,7 +179,7 @@ def test_docarray_inputs(make_flow, inputs):
                     Document(text='goodbye, world'),
                 ],
             )
-            for _ in range(10)
+            for _ in range(1)
         ),
         DocumentArray(
             [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -71,7 +71,7 @@ def test_server_download_not_regular_file(tmpdir):
         )
 
 
-def test_make_onnx_flow_wrong_name_path(port_generator):
+def test_make_onnx_flow_wrong_name_path():
     from clip_server.executors.clip_onnx import CLIPEncoder
 
     with pytest.raises(Exception):

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -76,6 +76,8 @@ def test_docarray_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
+    if hasattr(inputs, '__len__'):
+        assert inputs[0] is r[0]
     assert r.embeddings.shape
     assert '__created_by_CAS__' not in r[0].tags
     assert '__loaded_by_CAS__' not in r[0].tags
@@ -104,6 +106,7 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
+    assert inputs[0] is r[0]
     assert r.embeddings.shape
     assert r.contents == inputs.contents
     assert '__created_by_CAS__' not in r[0].tags
@@ -130,14 +133,14 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
     ],
 )
 def test_docarray_traversal(make_flow, inputs, port_generator):
+    from jina import Client as _Client
+
     da = DocumentArray.empty(1)
     da[0].chunks = inputs
 
-    from jina import Client as _Client
-
     c = _Client(host=f'grpc://0.0.0.0', port=make_flow.port)
     r1 = c.post(on='/', inputs=da, parameters={'traversal_paths': '@c'})
-    r2 = c.post(on='/', inputs=da, parameters={'access_paths': '@c'})
+    assert isinstance(r1, DocumentArray)
     assert r1[0].chunks.embeddings.shape[0] == len(inputs)
     assert '__created_by_CAS__' not in r1[0].tags
     assert '__loaded_by_CAS__' not in r1[0].tags
@@ -145,6 +148,9 @@ def test_docarray_traversal(make_flow, inputs, port_generator):
     assert not r1[0].blob
     assert not r1[0].chunks[0].tensor
     assert not r1[0].chunks[0].blob
+
+    r2 = c.post(on='/', inputs=da, parameters={'access_paths': '@c'})
+    assert isinstance(r2, DocumentArray)
     assert r2[0].chunks.embeddings.shape[0] == len(inputs)
     assert '__created_by_CAS__' not in r2[0].tags
     assert '__loaded_by_CAS__' not in r2[0].tags

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -43,7 +43,6 @@ def test_protocols(port_generator, protocol, jit, pytestconfig):
 def test_plain_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
-
     assert (
         r.shape[0] == len(list(inputs)) if not callable(inputs) else len(list(inputs()))
     )
@@ -76,13 +75,13 @@ def test_docarray_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
-    if hasattr(inputs, '__len__'):
-        assert inputs[0] is r[0]
     assert r.embeddings.shape
     assert '__created_by_CAS__' not in r[0].tags
     assert '__loaded_by_CAS__' not in r[0].tags
     assert not r[0].tensor
     assert not r[0].blob
+    if hasattr(inputs, '__len__'):
+        assert inputs[0] is r[0]
 
 
 @pytest.mark.parametrize(
@@ -106,13 +105,13 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
-    assert inputs[0] is r[0]
     assert r.embeddings.shape
     assert r.contents == inputs.contents
     assert '__created_by_CAS__' not in r[0].tags
     assert '__loaded_by_CAS__' not in r[0].tags
     assert not r[0].tensor
     assert not r[0].blob
+    assert inputs[0] is r[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -162,8 +162,8 @@ def test_docarray_traversal(make_flow, inputs):
 @pytest.mark.parametrize(
     'inputs',
     [
-        [Document(text='hello, world') for _ in range(20)],
-        DocumentArray([Document(text='hello, world') for _ in range(20)]),
+        [Document(id=str(i), text='hello, world') for i in range(20)],
+        DocumentArray([Document(id=str(i), text='hello, world') for i in range(20)]),
     ],
 )
 def test_docarray_preserve_original_order(make_flow, inputs):
@@ -172,3 +172,4 @@ def test_docarray_preserve_original_order(make_flow, inputs):
     assert isinstance(r, DocumentArray)
     for i in range(len(inputs)):
         assert inputs[i] is r[i]
+        assert inputs[i].id == str(i)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -40,7 +40,7 @@ def test_protocols(port_generator, protocol, jit, pytestconfig):
         ],
     ],
 )
-def test_plain_inputs(make_flow, inputs, port_generator):
+def test_plain_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert (
@@ -71,7 +71,7 @@ def test_plain_inputs(make_flow, inputs, port_generator):
         ),
     ],
 )
-def test_docarray_inputs(make_flow, inputs, port_generator):
+def test_docarray_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
@@ -101,7 +101,7 @@ def test_docarray_inputs(make_flow, inputs, port_generator):
         ),
     ],
 )
-def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
+def test_docarray_preserve_original_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
@@ -131,7 +131,7 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
         ),
     ],
 )
-def test_docarray_traversal(make_flow, inputs, port_generator):
+def test_docarray_traversal(make_flow, inputs):
     from jina import Client as _Client
 
     da = DocumentArray.empty(1)
@@ -157,3 +157,18 @@ def test_docarray_traversal(make_flow, inputs, port_generator):
     assert not r2[0].blob
     assert not r2[0].chunks[0].tensor
     assert not r2[0].chunks[0].blob
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [Document(text='hello, world') for _ in range(20)],
+        DocumentArray([Document(text='hello, world') for _ in range(20)]),
+    ],
+)
+def test_docarray_preserve_original_order(make_flow, inputs):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    r = c.encode(inputs if not callable(inputs) else inputs(), batch_size=1)
+    assert isinstance(r, DocumentArray)
+    for i in range(len(inputs)):
+        assert inputs[i] is r[i]

--- a/tests/test_tensorrt.py
+++ b/tests/test_tensorrt.py
@@ -36,8 +36,9 @@ def test_docarray_inputs(make_trt_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_trt_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
-    assert inputs[0] is r[0]
     assert r.embeddings.shape
+    if hasattr(inputs, '__len__'):
+        assert inputs[0] is r[0]
 
 
 @pytest.mark.gpu

--- a/tests/test_tensorrt.py
+++ b/tests/test_tensorrt.py
@@ -36,6 +36,7 @@ def test_docarray_inputs(make_trt_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_trt_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
+    assert inputs[0] is r[0]
     assert r.embeddings.shape
 
 
@@ -63,6 +64,7 @@ async def test_async_arank(make_trt_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_trt_flow.port}')
     r = await c.arank([d])
     assert isinstance(r, DocumentArray)
+    assert d is r[0]
     rv = r['@m', 'scores__clip_score__value']
     for v in rv:
         assert v is not None


### PR DESCRIPTION
This PR introduces the following changes to CAS:

- [x] `clip_client` used to return a copy of the input with embeddings and ranking Infos in it. It now updates these into the original input.
- [x] the output order is preserved using uid and is now the same as the input order
      **Notice**: the result is not complete if the ids of input are not unique
- [x] return empty list or docarray for empty inputs
- [x] test cases


Basic tests for memory usage:
```{python}
from clip_client import Client
from docarray import Document, DocumentArray
import psutil

def func():
    c = Client('grpc://0.0.0.0:51000')

    da = DocumentArray()
    for _ in range(8):
        da.append(Document(uri='toy.jpeg'))

    r = c.encode(da)
    return da, r

if __name__ == '__main__':
    mem = []
    for _ in range(10):
        a, b = func()
        mem.append(psutil.Process().memory_info().rss / 1024**2)
    print(mem)
    print(sum(mem)/len(mem))
```

Send 10 batches of images with each batch_size = 8

before (no in-place) in MB: 

> 76.23828125, 76.98046875, 78.0234375, 78.99609375, 79.8125, 79.953125, 73.06640625, 73.42578125, 73.6484375, 74.0703125
> avg 76.421484375

after (in-place) in MB: 

> 73.96875, 71.5703125, 72.72265625, 73.1875, 73.3671875, 73.67578125, 74.2265625, 74.234375, 74.26171875, 72.33203125
> avg 73.3546875


Basic tests for time usage:

```{python}
from clip_client import Client
from docarray import Document, DocumentArray
import time

def func():
    c = Client('grpc://0.0.0.0:51000')

    da = DocumentArray()
    for _ in range(1000):
        da.append(Document(uri='toy.jpeg'))
    c.encode(da, show_progress=True)

if __name__ == '__main__':
    timecost = []
    for _ in range(10):
        t1 = time.time()
        func()
        t2 = time.time()
        timecost.append(t2-t1)
    print(timecost)
    print(sum(timecost)/len(timecost))
```

Time for encoding 1000 images (local machine with CPU):

before (no in-place) in second: 

> 229.51802515983582, 228.4744529724121, 228.77719569206238, 229.18066692352295, 228.6370599269867, 228.76180005073547, 228.8146288394928, 234.90695881843567, 264.61701130867004, 268.92049384117126
> avg 237.0608293533325

after (in-place) in second: 

> 230.03532719612122, 229.0823450088501, 228.96690702438354, 229.40257811546326, 228.63984608650208, 228.8968267440796, 229.03895783424377, 229.23136687278748, 229.0418107509613, 229.43238496780396
> avg 229.17683506011963


Another test to encode 10000 images (local with CPU):

> before (no in-place) 2307.465388059616 s

> after (in-place) 2306.363124847412 s


Test to encode 10000 images 10 times (GPU server):

before (no in-place) in second: 

> 33.92143511772156, 33.70487380027771, 33.75519323348999, 33.83939599990845, 33.79131293296814, 33.8446307182312, 33.81287407875061, 33.930410385131836, 33.99196481704712, 33.83139514923096
> avg 33.842348623275754

after (in-place) in second: 

> 34.06313490867615, 33.81302094459534, 33.66564702987671, 33.78828310966492, 33.66629767417908, 33.921727657318115, 33.7433865070343, 33.724066972732544, 33.69422483444214, 33.75126600265503
> avg 33.783105564117434


we don't observe a substantial difference after this change