### PR TITLE
feat: add option on server to remove input image content after encoding to save space

### DIFF
--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -126,7 +126,7 @@ class Client:
             self._client.post(
                 on=f'/encode/{model_name}'.rstrip('/'),
                 **self._get_post_payload(content, results, kwargs),
-                on_done=partial(self._gather_result, results=results),
+                on_done=partial(self._gather_encode_result, results=results),
                 parameters=parameters,
             )
 
@@ -137,8 +137,7 @@ class Client:
         _unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, _unbox)
 
-
-    def _gather_result(self, response, results: 'DocumentArray'):
+    def _gather_encode_result(self, response, results: 'DocumentArray'):
         from rich import filesize
 
         r = response.data.docs
@@ -459,7 +458,7 @@ class Client:
         """
         self._prepare_streaming(
             not kwargs.get('show_progress'),
-            total=len(docs),
+            total=len(docs) if hasattr(docs, '__len__') else None,
         )
         results = DocumentArray()
         with self._pbar:
@@ -481,7 +480,7 @@ class Client:
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),
-            total=len(docs),
+            total=len(docs) if hasattr(docs, '__len__') else None,
         )
         results = DocumentArray()
         with self._pbar:
@@ -511,6 +510,7 @@ class Client:
 
         return results
 
+    def _gather_rank_result(self, response, docs_copy: 'DocumentArray'):
     @overload
     def index(
         self,

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -176,17 +176,15 @@ class Client:
                 _mime = mimetypes.guess_type(c)[0]
                 if _mime and _mime.startswith('image'):
                     d = Document(
-                        tags={'__created_by_CAS__': True, '__loaded_by_CAS__': True},
                         uri=c,
                     ).load_uri_to_blob()
                 else:
-                    d = Document(tags={'__created_by_CAS__': True}, text=c)
+                    d = Document(text=c)
             elif isinstance(c, Document):
                 if c.content_type in ('text', 'blob'):
                     d = c
                 elif not c.blob and c.uri:
                     c.load_uri_to_blob()
-                    c.tags['__loaded_by_CAS__'] = True
                     d = c
                 elif c.tensor is not None:
                     d = c
@@ -288,8 +286,10 @@ class Client:
 
         results = DocumentArray()
         with self._pbar:
-            parameters = kwargs.pop('parameters', None)
+            parameters = kwargs.pop('parameters', {})
+            parameters['drop_image_content'] = True
             model_name = parameters.pop('model_name', '') if parameters else ''
+
             self._client.post(
                 on=f'/encode/{model_name}'.rstrip('/'),
                 **self._get_post_payload(content, results, kwargs),
@@ -298,10 +298,6 @@ class Client:
                 ),
                 parameters=parameters,
             )
-
-        for r in results:
-            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
-                r.pop('blob')
 
         unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, unbox)
@@ -345,7 +341,8 @@ class Client:
 
         results = DocumentArray()
         with self._pbar:
-            parameters = kwargs.pop('parameters', None)
+            parameters = kwargs.pop('parameters', {})
+            parameters['drop_image_content'] = True
             model_name = parameters.get('model_name', '') if parameters else ''
 
             async for da in self._async_client.post(
@@ -366,10 +363,6 @@ class Client:
                         )
                     ),
                 )
-
-        for r in results:
-            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
-                r.pop('blob')
 
         unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, unbox)
@@ -423,7 +416,6 @@ class Client:
             return d
         elif not d.blob and d.uri:
             d.load_uri_to_blob()
-            d.tags['__loaded_by_CAS__'] = True
             return d
         elif d.tensor is not None:
             return d
@@ -437,18 +429,6 @@ class Client:
             raise ValueError(f'`.rank()` requires every doc to have `.{_source}`')
         d = Client._prepare_single_doc(d)
         setattr(d, _source, [Client._prepare_single_doc(c) for c in _get(d)])
-        return d
-
-    @staticmethod
-    def _reset_rank_doc(d: 'Document', _source: str = 'matches'):
-        _get = lambda d: getattr(d, _source)
-
-        if d.tags.pop('__loaded_by_CAS__', False):
-            d.pop('blob')
-
-        for c in _get(d):
-            if c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
         return d
 
     def rank(
@@ -474,8 +454,10 @@ class Client:
 
         results = DocumentArray()
         with self._pbar:
-            parameters = kwargs.pop('parameters', None)
+            parameters = kwargs.pop('parameters', {})
+            parameters['drop_image_content'] = True
             model_name = parameters.get('model_name', '') if parameters else ''
+
             self._client.post(
                 on=f'/rank/{model_name}'.rstrip('/'),
                 **self._get_rank_payload(docs, results, kwargs),
@@ -484,9 +466,6 @@ class Client:
                 ),
                 parameters=parameters,
             )
-
-        for r in results:
-            self._reset_rank_doc(r, _source=kwargs.get('source', 'matches'))
 
         return results
 
@@ -507,8 +486,10 @@ class Client:
 
         results = DocumentArray()
         with self._pbar:
-            parameters = kwargs.pop('parameters', None)
+            parameters = kwargs.pop('parameters', {})
+            parameters['drop_image_content'] = True
             model_name = parameters.get('model_name', '') if parameters else ''
+
             async for da in self._async_client.post(
                 on=f'/rank/{model_name}'.rstrip('/'),
                 **self._get_rank_payload(docs, results, kwargs),
@@ -527,9 +508,6 @@ class Client:
                         )
                     ),
                 )
-
-        for r in results:
-            self._reset_rank_doc(r, _source=kwargs.get('source', 'matches'))
 
         return results
 
@@ -581,14 +559,19 @@ class Client:
             raise TypeError(
                 f'content must be an Iterable of [str, Document], try `.index(["{content}"])` instead'
             )
+        if hasattr(content, '__len__') and len(content) == 0:
+            return DocumentArray()
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),
             total=len(content) if hasattr(content, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
-            parameters = kwargs.pop('parameters', None)
+            parameters = kwargs.pop('parameters', {})
+            parameters['drop_image_content'] = True
+
             self._client.post(
                 on='/index',
                 **self._get_post_payload(content, results, kwargs),
@@ -597,10 +580,6 @@ class Client:
                 ),
                 parameters=parameters,
             )
-
-        for r in results:
-            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
-                r.pop('blob')
 
         return results
 
@@ -633,17 +612,23 @@ class Client:
             raise TypeError(
                 f'content must be an Iterable of [str, Document], try `.aindex(["{content}"])` instead'
             )
+        if hasattr(content, '__len__') and len(content) == 0:
+            return DocumentArray()
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),
             total=len(content) if hasattr(content, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
+            parameters = kwargs.pop('parameters', {})
+            parameters['drop_image_content'] = True
+
             async for da in self._async_client.post(
                 on='/index',
                 **self._get_post_payload(content, results, kwargs),
-                parameters=kwargs.pop('parameters', None),
+                parameters=parameters,
             ):
                 results[da[:, 'id']].embeddings = da.embeddings
 
@@ -658,10 +643,6 @@ class Client:
                         )
                     ),
                 )
-
-        for r in results:
-            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
-                r.pop('blob')
 
         return results
 
@@ -716,15 +697,19 @@ class Client:
             raise TypeError(
                 f'content must be an Iterable of [str, Document], try `.search(["{content}"])` instead'
             )
+        if hasattr(content, '__len__') and len(content) == 0:
+            return DocumentArray()
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),
             total=len(content) if hasattr(content, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', {})
             parameters['limit'] = limit
+            parameters['drop_image_content'] = True
 
             self._client.post(
                 on='/search',
@@ -734,10 +719,6 @@ class Client:
                     self._gather_result, results=results, attribute='matches'
                 ),
             )
-
-        for r in results:
-            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
-                r.pop('blob')
 
         return results
 
@@ -772,16 +753,19 @@ class Client:
             raise TypeError(
                 f'content must be an Iterable of [str, Document], try `.asearch(["{content}"])` instead'
             )
+        if hasattr(content, '__len__') and len(content) == 0:
+            return DocumentArray()
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),
             total=len(content) if hasattr(content, '__len__') else None,
         )
-        results = DocumentArray()
 
+        results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', {})
             parameters['limit'] = limit
+            parameters['drop_image_content'] = True
 
             async for da in self._async_client.post(
                 on='/search',
@@ -801,9 +785,5 @@ class Client:
                         )
                     ),
                 )
-
-        for r in results:
-            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
-                r.pop('blob')
 
         return results

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -463,6 +463,7 @@ class Client:
             not kwargs.get('show_progress'),
             total=len(docs) if hasattr(docs, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', None)
@@ -488,6 +489,7 @@ class Client:
             not kwargs.get('show_progress'),
             total=len(docs) if hasattr(docs, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', None)

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -144,7 +144,7 @@ class Client:
         )
 
     def _gather_result(
-        self, response, results: 'DocumentArray', attribute: Optional[str] = ''
+        self, response, results: 'DocumentArray', attribute: Optional[str] = None
     ):
         from rich import filesize
 
@@ -171,7 +171,7 @@ class Client:
         if hasattr(self, '_pbar'):
             self._pbar.start_task(self._s_task)
 
-        for i, c in enumerate(content):
+        for c in content:
             if isinstance(c, str):
                 _mime = mimetypes.guess_type(c)[0]
                 if _mime and _mime.startswith('image'):
@@ -299,9 +299,9 @@ class Client:
                 parameters=parameters,
             )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, unbox)
@@ -367,9 +367,9 @@ class Client:
                     ),
                 )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, unbox)
@@ -383,7 +383,7 @@ class Client:
         if hasattr(self, '_pbar'):
             self._pbar.start_task(self._s_task)
 
-        for i, c in enumerate(content):
+        for c in content:
             if isinstance(c, Document):
                 d = self._prepare_rank_doc(c, source)
             else:
@@ -443,15 +443,21 @@ class Client:
     def _reset_rank_doc(d: 'Document', _source: str = 'matches'):
         _get = lambda d: getattr(d, _source)
 
+        print(123123)
         if d.tags.pop('__loaded_by_CAS__', False):
+            print(111)
             d.pop('blob')
+        else:
+            print(222)
 
         for c in _get(d):
             if c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
         return d
 
-    def rank(self, docs: Iterable['Document'], **kwargs) -> 'DocumentArray':
+    def rank(
+        self, docs: Union['DocumentArray', Iterable['Document']], **kwargs
+    ) -> 'DocumentArray':
         """Rank image-text matches according to the server CLIP model.
         Given a Document with nested matches, where the root is image/text and the matches is in another modality, i.e.
         text/image; this method ranks the matches according to the CLIP model.
@@ -480,8 +486,9 @@ class Client:
                 ),
                 parameters=parameters,
             )
-        for d in docs:
-            self._reset_rank_doc(d, _source=kwargs.get('source', 'matches'))
+
+        for r in results:
+            self._reset_rank_doc(r, _source=kwargs.get('source', 'matches'))
 
         return results
 
@@ -519,8 +526,8 @@ class Client:
                     ),
                 )
 
-        for d in docs:
-            self._reset_rank_doc(d, _source=kwargs.get('source', 'matches'))
+        for r in results:
+            self._reset_rank_doc(r, _source=kwargs.get('source', 'matches'))
 
         return results
 
@@ -589,9 +596,9 @@ class Client:
                 parameters=parameters,
             )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         return results
 
@@ -650,9 +657,9 @@ class Client:
                     ),
                 )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         return results
 
@@ -726,9 +733,9 @@ class Client:
                 ),
             )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         return results
 
@@ -793,8 +800,8 @@ class Client:
                     ),
                 )
 
-        for c in content:
-            if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
-                c.pop('blob')
+        for r in results:
+            if hasattr(r, 'tags') and r.tags.pop('__loaded_by_CAS__', False):
+                r.pop('blob')
 
         return results

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -313,6 +313,7 @@ class Client:
         *,
         batch_size: Optional[int] = None,
         show_progress: bool = False,
+        parameters: Optional[dict] = None,
     ) -> 'np.ndarray':
         ...
 
@@ -323,6 +324,7 @@ class Client:
         *,
         batch_size: Optional[int] = None,
         show_progress: bool = False,
+        parameters: Optional[dict] = None,
     ) -> 'DocumentArray':
         ...
 

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -118,6 +118,7 @@ class Client:
             not kwargs.get('show_progress'),
             total=len(content) if hasattr(content, '__len__') else None,
         )
+
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', None)

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -492,7 +492,9 @@ class Client:
 
         return results
 
-    async def arank(self, docs: Iterable['Document'], **kwargs) -> 'DocumentArray':
+    async def arank(
+        self, docs: Union['DocumentArray', Iterable['Document']], **kwargs
+    ) -> 'DocumentArray':
         from rich import filesize
 
         if hasattr(docs, '__len__') and len(docs) == 0:

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -443,12 +443,8 @@ class Client:
     def _reset_rank_doc(d: 'Document', _source: str = 'matches'):
         _get = lambda d: getattr(d, _source)
 
-        print(123123)
         if d.tags.pop('__loaded_by_CAS__', False):
-            print(111)
             d.pop('blob')
-        else:
-            print(222)
 
         for c in _get(d):
             if c.tags.pop('__loaded_by_CAS__', False):
@@ -466,6 +462,8 @@ class Client:
         :param docs: the input Documents
         :return: the ranked Documents in a DocumentArray.
         """
+        if isinstance(docs, str):
+            raise TypeError(f'Content must be an Iterable of [Document]')
         if hasattr(docs, '__len__') and len(docs) == 0:
             return DocumentArray() if isinstance(docs, DocumentArray) else []
 
@@ -497,6 +495,8 @@ class Client:
     ) -> 'DocumentArray':
         from rich import filesize
 
+        if isinstance(docs, str):
+            raise TypeError(f'Content must be an Iterable of [Document]')
         if hasattr(docs, '__len__') and len(docs) == 0:
             return DocumentArray() if isinstance(docs, DocumentArray) else []
 

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -1,7 +1,6 @@
 import mimetypes
 import os
 import time
-import types
 import warnings
 from typing import (
     overload,

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -333,7 +333,7 @@ class Client:
 
         if isinstance(content, str):
             raise TypeError(
-                f'Content must be an Iterable of [str, Document], try `.encode(["{content}"])` instead'
+                f'Content must be an Iterable of [str, Document], try `.aencode(["{content}"])` instead'
             )
         if hasattr(content, '__len__') and len(content) == 0:
             return DocumentArray() if isinstance(content, DocumentArray) else []
@@ -593,7 +593,7 @@ class Client:
             if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
-        return self._unboxed_result(results)
+        return results
 
     @overload
     async def aindex(
@@ -619,6 +619,11 @@ class Client:
 
     async def aindex(self, content, **kwargs):
         from rich import filesize
+
+        if isinstance(content, str):
+            raise TypeError(
+                f'content must be an Iterable of [str, Document], try `.aindex(["{content}"])` instead'
+            )
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),
@@ -649,7 +654,7 @@ class Client:
             if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
-        return self._unboxed_result(results)
+        return results
 
     @overload
     def search(
@@ -753,6 +758,11 @@ class Client:
 
     async def asearch(self, content, limit: int = 10, **kwargs):
         from rich import filesize
+
+        if isinstance(content, str):
+            raise TypeError(
+                f'content must be an Iterable of [str, Document], try `.asearch(["{content}"])` instead'
+            )
 
         self._prepare_streaming(
             not kwargs.get('show_progress'),

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -133,8 +133,9 @@ class Client:
             if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
-        _unbox = isinstance(content, list) and isinstance(content[0], str)
+        _unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, _unbox)
+
 
     def _gather_result(self, response, results: 'DocumentArray'):
         from rich import filesize
@@ -313,7 +314,6 @@ class Client:
             total=len(content) if hasattr(content, '__len__') else None,
         )
 
-
         results = DocumentArray()
         with self._pbar:
             parameters = kwargs.pop('parameters', None)
@@ -342,7 +342,7 @@ class Client:
             if hasattr(c, 'tags') and c.tags.pop('__loaded_by_CAS__', False):
                 c.pop('blob')
 
-        _unbox = isinstance(content, list) and isinstance(content[0], str)
+        _unbox = hasattr(content, '__len__') and isinstance(content[0], str)
         return self._unboxed_result(results, _unbox)
 
     def _prepare_streaming(self, disable, total):

--- a/server/clip_server/executors/clip_onnx.py
+++ b/server/clip_server/executors/clip_onnx.py
@@ -26,7 +26,6 @@ class CLIPEncoder(Executor):
         minibatch_size: int = 32,
         access_paths: str = '@r',
         model_path: Optional[str] = None,
-        drop_image_content: bool = False,
         **kwargs,
     ):
         """
@@ -41,12 +40,10 @@ class CLIPEncoder(Executor):
         :param model_path: The path to the model to be used. If not specified, the model will be downloaded or loaded
             from the local cache. Visit https://clip-as-service.jina.ai/user-guides/server/#use-custom-model-for-onnx
             to learn how to finetune custom models.
-        :param drop_image_content: Whether to drop the image content from the input documents. Default is False.
         """
         super().__init__(**kwargs)
 
         self._minibatch_size = minibatch_size
-        self._drop_image_content = drop_image_content
         self._access_paths = access_paths
         if 'traversal_paths' in kwargs:
             warnings.warn(
@@ -124,10 +121,8 @@ class CLIPEncoder(Executor):
 
     @requests(on='/rank')
     async def rank(self, docs: 'DocumentArray', parameters: Dict, **kwargs):
-        drop_image_content = parameters.get(
-            'drop_image_content', self._drop_image_content
-        )
-        await self.encode(docs['@r,m'], drop_image_content=drop_image_content)
+        _drop_image_content = parameters.get('drop_image_content', False)
+        await self.encode(docs['@r,m'], drop_image_content=_drop_image_content)
 
         set_rank(docs)
 
@@ -139,9 +134,7 @@ class CLIPEncoder(Executor):
                 f'`traversal_paths` is deprecated. Use `access_paths` instead.'
             )
             access_paths = parameters['traversal_paths']
-        drop_image_content = parameters.get(
-            'drop_image_content', self._drop_image_content
-        )
+        _drop_image_content = parameters.get('drop_image_content', False)
 
         _img_da = DocumentArray()
         _txt_da = DocumentArray()
@@ -151,7 +144,7 @@ class CLIPEncoder(Executor):
         # for image
         if _img_da:
             for minibatch, batch_data in _img_da.map_batch(
-                partial(self._preproc_images, drop_image_content=drop_image_content),
+                partial(self._preproc_images, drop_image_content=_drop_image_content),
                 batch_size=self._minibatch_size,
                 pool=self._pool,
             ):

--- a/server/clip_server/executors/clip_torch.py
+++ b/server/clip_server/executors/clip_torch.py
@@ -27,7 +27,6 @@ class CLIPEncoder(Executor):
         num_worker_preprocess: int = 4,
         minibatch_size: int = 32,
         access_paths: str = '@r',
-        drop_image_content: bool = False,
         **kwargs,
     ):
         """
@@ -40,12 +39,10 @@ class CLIPEncoder(Executor):
             number if you encounter OOM errors.
         :param access_paths: The access paths to traverse on the input documents to get the images and texts to be
             processed. Visit https://docarray.jina.ai/fundamentals/documentarray/access-elements for more details.
-        :param drop_image_content: Whether to drop the image content from the input documents. Default is False.
         """
         super().__init__(**kwargs)
 
         self._minibatch_size = minibatch_size
-        self._drop_image_content = drop_image_content
         self._access_paths = access_paths
         if 'traversal_paths' in kwargs:
             warnings.warn(
@@ -105,10 +102,8 @@ class CLIPEncoder(Executor):
 
     @requests(on='/rank')
     async def rank(self, docs: 'DocumentArray', parameters: Dict, **kwargs):
-        drop_image_content = parameters.get(
-            'drop_image_content', self._drop_image_content
-        )
-        await self.encode(docs['@r,m'], drop_image_content=drop_image_content)
+        _drop_image_content = parameters.get('drop_image_content', False)
+        await self.encode(docs['@r,m'], drop_image_content=_drop_image_content)
 
         set_rank(docs)
 
@@ -120,9 +115,7 @@ class CLIPEncoder(Executor):
                 f'`traversal_paths` is deprecated. Use `access_paths` instead.'
             )
             access_paths = parameters['traversal_paths']
-        drop_image_content = parameters.get(
-            'drop_image_content', self._drop_image_content
-        )
+        _drop_image_content = parameters.get('drop_image_content', False)
 
         _img_da = DocumentArray()
         _txt_da = DocumentArray()
@@ -134,7 +127,7 @@ class CLIPEncoder(Executor):
             if _img_da:
                 for minibatch, batch_data in _img_da.map_batch(
                     partial(
-                        self._preproc_images, drop_image_content=drop_image_content
+                        self._preproc_images, drop_image_content=_drop_image_content
                     ),
                     batch_size=self._minibatch_size,
                     pool=self._pool,

--- a/server/clip_server/executors/clip_torch.py
+++ b/server/clip_server/executors/clip_torch.py
@@ -2,6 +2,7 @@ import os
 import warnings
 from multiprocessing.pool import ThreadPool
 from typing import Optional, Dict
+from functools import partial
 
 import numpy as np
 import torch
@@ -26,6 +27,7 @@ class CLIPEncoder(Executor):
         num_worker_preprocess: int = 4,
         minibatch_size: int = 32,
         access_paths: str = '@r',
+        drop_image_content: bool = False,
         **kwargs,
     ):
         """
@@ -38,10 +40,12 @@ class CLIPEncoder(Executor):
             number if you encounter OOM errors.
         :param access_paths: The access paths to traverse on the input documents to get the images and texts to be
             processed. Visit https://docarray.jina.ai/fundamentals/documentarray/access-elements for more details.
+        :param drop_image_content: Whether to drop the image content from the input documents. Default is False.
         """
         super().__init__(**kwargs)
 
         self._minibatch_size = minibatch_size
+        self._drop_image_content = drop_image_content
         self._access_paths = access_paths
         if 'traversal_paths' in kwargs:
             warnings.warn(
@@ -77,7 +81,7 @@ class CLIPEncoder(Executor):
         self._tokenizer = Tokenizer(name)
         self._image_transform = clip._transform_ndarray(self._model.image_size)
 
-    def _preproc_images(self, docs: 'DocumentArray'):
+    def _preproc_images(self, docs: 'DocumentArray', drop_image_content: bool):
         with self.monitor(
             name='preprocess_images_seconds',
             documentation='images preprocess time in seconds',
@@ -87,6 +91,7 @@ class CLIPEncoder(Executor):
                 preprocess_fn=self._image_transform,
                 device=self._device,
                 return_np=False,
+                drop_image_content=drop_image_content,
             )
 
     def _preproc_texts(self, docs: 'DocumentArray'):
@@ -100,7 +105,10 @@ class CLIPEncoder(Executor):
 
     @requests(on='/rank')
     async def rank(self, docs: 'DocumentArray', parameters: Dict, **kwargs):
-        await self.encode(docs['@r,m'])
+        drop_image_content = parameters.get(
+            'drop_image_content', self._drop_image_content
+        )
+        await self.encode(docs['@r,m'], drop_image_content=drop_image_content)
 
         set_rank(docs)
 
@@ -112,6 +120,9 @@ class CLIPEncoder(Executor):
                 f'`traversal_paths` is deprecated. Use `access_paths` instead.'
             )
             access_paths = parameters['traversal_paths']
+        drop_image_content = parameters.get(
+            'drop_image_content', self._drop_image_content
+        )
 
         _img_da = DocumentArray()
         _txt_da = DocumentArray()
@@ -122,7 +133,9 @@ class CLIPEncoder(Executor):
             # for image
             if _img_da:
                 for minibatch, batch_data in _img_da.map_batch(
-                    self._preproc_images,
+                    partial(
+                        self._preproc_images, drop_image_content=drop_image_content
+                    ),
                     batch_size=self._minibatch_size,
                     pool=self._pool,
                 ):

--- a/server/clip_server/executors/helper.py
+++ b/server/clip_server/executors/helper.py
@@ -21,6 +21,7 @@ def preproc_image(
     preprocess_fn: Callable,
     device: str = 'cpu',
     return_np: bool = False,
+    drop_image_content: bool = False,
 ) -> Tuple['DocumentArray', Dict]:
 
     tensors_batch = []
@@ -37,10 +38,10 @@ def preproc_image(
         tensors_batch.append(preprocess_fn(d.tensor).detach())
 
         # recover doc content
-        if d.tags.pop('__loaded_by_CAS__', False):
+        d.content = content
+        if drop_image_content:
+            d.pop('blob')
             d.pop('tensor')
-        else:
-            d.content = content
 
     tensors_batch = torch.stack(tensors_batch).type(torch.float32)
 

--- a/server/clip_server/executors/helper.py
+++ b/server/clip_server/executors/helper.py
@@ -40,8 +40,7 @@ def preproc_image(
         # recover doc content
         d.content = content
         if drop_image_content:
-            d.pop('blob')
-            d.pop('tensor')
+            d.pop('blob', 'tensor')
 
     tensors_batch = torch.stack(tensors_batch).type(torch.float32)
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -45,6 +45,7 @@ async def test_async_docarray_preserve_original_inputs(
     t2 = asyncio.create_task(c.aencode(inputs if not callable(inputs) else inputs()))
     await asyncio.gather(t1, t2)
     assert isinstance(t2.result(), DocumentArray)
+    assert inputs[0] is t2.result()[0]
     assert t2.result().embeddings.shape
     assert t2.result().contents == inputs.contents
     assert '__created_by_CAS__' not in t2.result()[0].tags

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -37,9 +37,7 @@ async def test_async_encode(make_flow):
     ],
 )
 @pytest.mark.asyncio
-async def test_async_docarray_preserve_original_inputs(
-    make_flow, inputs, port_generator
-):
+async def test_async_docarray_preserve_original_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     t1 = asyncio.create_task(another_heavylifting_job())
     t2 = asyncio.create_task(c.aencode(inputs if not callable(inputs) else inputs()))
@@ -52,3 +50,23 @@ async def test_async_docarray_preserve_original_inputs(
     assert not t2.result()[0].tensor
     assert not t2.result()[0].blob
     assert inputs[0] is t2.result()[0]
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [Document(text='hello, world') for _ in range(20)],
+        DocumentArray([Document(text='hello, world') for _ in range(20)]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_docarray_preserve_original_order(make_flow, inputs):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    t1 = asyncio.create_task(another_heavylifting_job())
+    t2 = asyncio.create_task(
+        c.aencode(inputs if not callable(inputs) else inputs(), batch_size=1)
+    )
+    await asyncio.gather(t1, t2)
+    assert isinstance(t2.result(), DocumentArray)
+    for i in range(len(inputs)):
+        assert inputs[i] is t2.result()[i]

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -45,10 +45,7 @@ async def test_async_docarray_preserve_original_inputs(make_flow, inputs):
     assert isinstance(t2.result(), DocumentArray)
     assert t2.result().embeddings.shape
     assert t2.result().contents == inputs.contents
-    assert '__created_by_CAS__' not in t2.result()[0].tags
-    assert '__loaded_by_CAS__' not in t2.result()[0].tags
     assert not t2.result()[0].tensor
-    assert not t2.result()[0].blob
     assert inputs[0] is t2.result()[0]
 
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -55,8 +55,8 @@ async def test_async_docarray_preserve_original_inputs(make_flow, inputs):
 @pytest.mark.parametrize(
     'inputs',
     [
-        [Document(text='hello, world') for _ in range(20)],
-        DocumentArray([Document(text='hello, world') for _ in range(20)]),
+        [Document(id=str(i), text='hello, world') for i in range(20)],
+        DocumentArray([Document(id=str(i), text='hello, world') for i in range(20)]),
     ],
 )
 @pytest.mark.asyncio
@@ -70,3 +70,4 @@ async def test_async_docarray_preserve_original_order(make_flow, inputs):
     assert isinstance(t2.result(), DocumentArray)
     for i in range(len(inputs)):
         assert inputs[i] is t2.result()[i]
+        assert inputs[i].id == str(i)

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -45,10 +45,10 @@ async def test_async_docarray_preserve_original_inputs(
     t2 = asyncio.create_task(c.aencode(inputs if not callable(inputs) else inputs()))
     await asyncio.gather(t1, t2)
     assert isinstance(t2.result(), DocumentArray)
-    assert inputs[0] is t2.result()[0]
     assert t2.result().embeddings.shape
     assert t2.result().contents == inputs.contents
     assert '__created_by_CAS__' not in t2.result()[0].tags
     assert '__loaded_by_CAS__' not in t2.result()[0].tags
     assert not t2.result()[0].tensor
     assert not t2.result()[0].blob
+    assert inputs[0] is t2.result()[0]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,3 +107,27 @@ async def test_client_empty_input(make_flow, inputs):
     else:
         assert isinstance(r, list)
     assert len(r) == 0
+
+
+@pytest.mark.asyncio
+async def test_str_input(make_torch_flow):
+    from clip_client.client import Client
+
+    c = Client(server=f'grpc://0.0.0.0:{make_torch_flow.port}')
+
+    with pytest.raises(Exception):
+        c.encode('hello')
+    with pytest.raises(Exception):
+        await c.aencode('hello')
+    with pytest.raises(Exception):
+        c.rank('hello')
+    with pytest.raises(Exception):
+        await c.arank('hello')
+    with pytest.raises(Exception):
+        c.index('hello')
+    with pytest.raises(Exception):
+        await c.aindex('hello')
+    with pytest.raises(Exception):
+        c.search('hello')
+    with pytest.raises(Exception):
+        await c.asearch('hello')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -108,6 +108,22 @@ async def test_client_empty_input(make_torch_flow, inputs):
         assert isinstance(r, list)
     assert len(r) == 0
 
+    r = c.index(inputs if not callable(inputs) else inputs())
+    assert isinstance(r, DocumentArray)
+    assert len(r) == 0
+
+    r = await c.aindex(inputs if not callable(inputs) else inputs())
+    assert isinstance(r, DocumentArray)
+    assert len(r) == 0
+
+    r = c.search(inputs if not callable(inputs) else inputs())
+    assert isinstance(r, DocumentArray)
+    assert len(r) == 0
+
+    r = await c.asearch(inputs if not callable(inputs) else inputs())
+    assert isinstance(r, DocumentArray)
+    assert len(r) == 0
+
 
 @pytest.mark.asyncio
 async def test_wrong_input_type(make_torch_flow):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -79,11 +79,31 @@ async def test_client_empty_input(make_flow, inputs):
     from clip_client.client import Client
 
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
-    with pytest.raises(Exception):
-        c.encode(inputs if not callable(inputs) else inputs())
-    with pytest.raises(Exception):
-        await c.aencode(inputs if not callable(inputs) else inputs())
-    with pytest.raises(Exception):
-        c.rank(inputs if not callable(inputs) else inputs())
-    with pytest.raises(Exception):
-        await c.arank(inputs if not callable(inputs) else inputs())
+
+    r = c.encode(inputs if not callable(inputs) else inputs())
+    if isinstance(inputs, DocumentArray):
+        assert isinstance(r, DocumentArray)
+    else:
+        assert isinstance(r, list)
+    assert len(r) == 0
+
+    r = await c.aencode(inputs if not callable(inputs) else inputs())
+    if isinstance(inputs, DocumentArray):
+        assert isinstance(r, DocumentArray)
+    else:
+        assert isinstance(r, list)
+    assert len(r) == 0
+
+    r = c.rank(inputs if not callable(inputs) else inputs())
+    if isinstance(inputs, DocumentArray):
+        assert isinstance(r, DocumentArray)
+    else:
+        assert isinstance(r, list)
+    assert len(r) == 0
+
+    r = await c.arank(inputs if not callable(inputs) else inputs())
+    if isinstance(inputs, DocumentArray):
+        assert isinstance(r, DocumentArray)
+    else:
+        assert isinstance(r, list)
+    assert len(r) == 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,9 +74,16 @@ def test_client_large_input(make_flow):
         DocumentArray([]),
     ],
 )
-def test_client_empty_input(make_flow, inputs):
+@pytest.mark.asyncio
+async def test_client_empty_input(make_flow, inputs):
     from clip_client.client import Client
 
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     with pytest.raises(Exception):
         c.encode(inputs if not callable(inputs) else inputs())
+    with pytest.raises(Exception):
+        await c.aencode(inputs if not callable(inputs) else inputs())
+    with pytest.raises(Exception):
+        c.rank(inputs if not callable(inputs) else inputs())
+    with pytest.raises(Exception):
+        await c.arank(inputs if not callable(inputs) else inputs())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,12 +57,12 @@ def test_client_concurrent_requests(port_generator):
             assert len(set([d.id[:2] for d in r])) == 1
 
 
-def test_client_large_input(make_flow):
+def test_client_large_input(make_torch_flow):
     from clip_client.client import Client
 
     inputs = ['hello' for _ in range(600)]
 
-    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    c = Client(server=f'grpc://0.0.0.0:{make_torch_flow.port}')
     with pytest.warns(UserWarning):
         c.encode(inputs if not callable(inputs) else inputs())
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,7 +23,7 @@ class Exec2(Executor):
 
     @requests
     async def process(self, docs, **kwargs):
-        results = await self._client.aencode(docs, request_size=2)
+        results = await self._client.aencode(docs, batch_size=2)
         return results
 
 
@@ -75,10 +75,10 @@ def test_client_large_input(make_torch_flow):
     ],
 )
 @pytest.mark.asyncio
-async def test_client_empty_input(make_flow, inputs):
+async def test_client_empty_input(make_torch_flow, inputs):
     from clip_client.client import Client
 
-    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    c = Client(server=f'grpc://0.0.0.0:{make_torch_flow.port}')
 
     r = c.encode(inputs if not callable(inputs) else inputs())
     if isinstance(inputs, DocumentArray):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -65,3 +65,18 @@ def test_client_large_input(make_flow, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     with pytest.warns(UserWarning):
         c.encode(inputs if not callable(inputs) else inputs())
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [],
+        DocumentArray([]),
+    ],
+)
+def test_client_empty_input(make_flow, inputs, port_generator):
+    from clip_client.client import Client
+
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    with pytest.raises(Exception):
+        c.encode(inputs if not callable(inputs) else inputs())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,7 +57,7 @@ def test_client_concurrent_requests(port_generator):
             assert len(set([d.id[:2] for d in r])) == 1
 
 
-def test_client_large_input(make_flow, port_generator):
+def test_client_large_input(make_flow):
     from clip_client.client import Client
 
     inputs = ['hello' for _ in range(600)]
@@ -74,7 +74,7 @@ def test_client_large_input(make_flow, port_generator):
         DocumentArray([]),
     ],
 )
-def test_client_empty_input(make_flow, inputs, port_generator):
+def test_client_empty_input(make_flow, inputs):
     from clip_client.client import Client
 
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,7 +110,7 @@ async def test_client_empty_input(make_torch_flow, inputs):
 
 
 @pytest.mark.asyncio
-async def test_str_input(make_torch_flow):
+async def test_wrong_input_type(make_torch_flow):
     from clip_client.client import Client
 
     c = Client(server=f'grpc://0.0.0.0:{make_torch_flow.port}')

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -102,7 +102,7 @@ def test_preproc_image(inputs):
     preprocess_fn = clip._transform_ndarray(224)
     da, pixel_values = preproc_image(inputs, preprocess_fn)
     assert len(da) == 2
-    assert not da[0].blob
+    # assert not da[0].blob
     assert da[1].blob
     assert not da[0].tensor
     assert not da[1].tensor

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -87,10 +87,6 @@ def test_split_img_txt_da(inputs):
             [
                 Document(
                     uri='https://docarray.jina.ai/_static/favicon.png',
-                    tags={'__loaded_by_CAS__': True},
-                ).load_uri_to_blob(),
-                Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
                 ).load_uri_to_blob(),
             ]
         )
@@ -100,10 +96,8 @@ def test_preproc_image(inputs):
     from clip_server.model import clip
 
     preprocess_fn = clip._transform_ndarray(224)
-    da, pixel_values = preproc_image(inputs, preprocess_fn)
-    assert len(da) == 2
-    # assert not da[0].blob
-    assert da[1].blob
+    da, pixel_values = preproc_image(inputs, preprocess_fn, drop_image_content=True)
+    assert len(da) == 1
+    assert not da[0].blob
     assert not da[0].tensor
-    assert not da[1].tensor
     assert pixel_values.get('pixel_values') is not None

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -91,7 +91,6 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 def test_docarray_inputs(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.rank([d])
-    assert d is r[0]
     assert r[0].content == d.content
     assert r[0].matches.contents == d.matches.contents
     assert '__loaded_by_CAS__' not in d.tags
@@ -101,6 +100,7 @@ def test_docarray_inputs(make_flow, d):
     assert not d.matches[0].blob
     assert not d.matches[0].tensor
     assert isinstance(r, DocumentArray)
+    assert d is r[0]
     rv1 = r['@m', 'scores__clip_score__value']
     rv2 = r['@m', 'scores__clip_score_cosine__value']
     for v1, v2 in zip(rv1, rv2):
@@ -133,9 +133,9 @@ async def test_async_arank(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = await c.arank([d])
     assert isinstance(r, DocumentArray)
-    assert d is r[0]
     assert r[0].content == d.content
     assert r[0].matches.contents == d.matches.contents
+    assert d is r[0]
     rv = r['@m', 'scores__clip_score__value']
     for v in rv:
         assert v is not None

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -91,6 +91,7 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 def test_docarray_inputs(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.rank([d])
+    assert d is r[0]
     assert r[0].content == d.content
     assert r[0].matches.contents == d.matches.contents
     assert '__loaded_by_CAS__' not in d.tags
@@ -132,6 +133,7 @@ async def test_async_arank(make_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = await c.arank([d])
     assert isinstance(r, DocumentArray)
+    assert d is r[0]
     assert r[0].content == d.content
     assert r[0].matches.contents == d.matches.contents
     rv = r['@m', 'scores__clip_score__value']

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -30,14 +30,10 @@ async def test_torch_executor_rank_img2texts(encoder_class):
     for d in da:
         for c in d.matches:
             assert c.scores['clip_score'].value is not None
-            assert '__loaded_by_CAS__' not in c.tags
             assert not c.tensor
-            assert not c.blob
         org_score = d.matches[:, 'scores__clip_score__value']
         assert org_score == list(sorted(org_score, reverse=True))
-        assert '__loaded_by_CAS__' not in d.tags
         assert not d.tensor
-        assert not d.blob
 
 
 @pytest.mark.asyncio
@@ -59,13 +55,10 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
         for c in d.matches:
             assert c.scores['clip_score'].value is not None
             assert c.scores['clip_score_cosine'].value is not None
-            assert '__loaded_by_CAS__' not in c.tags
             assert not c.tensor
-            assert not c.blob
         np.testing.assert_almost_equal(
             sum(c.scores['clip_score'].value for c in d.matches), 1
         )
-        assert '__loaded_by_CAS__' not in d.tags
         assert not d.tensor
         assert not d.blob
 
@@ -135,8 +128,6 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 def test_docarray_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.rank(inputs if not callable(inputs) else inputs())
-    assert '__loaded_by_CAS__' not in r[0].tags
-    assert not r[0].blob
     assert not r[0].tensor
     assert isinstance(r, DocumentArray)
     rv1 = r['@m', 'scores__clip_score__value']
@@ -200,8 +191,6 @@ def test_docarray_inputs(make_flow, inputs):
 async def test_async_arank(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = await c.arank(inputs if not callable(inputs) else inputs())
-    assert '__loaded_by_CAS__' not in r[0].tags
-    assert not r[0].blob
     assert not r[0].tensor
     assert isinstance(r, DocumentArray)
     rv = r['@m', 'scores__clip_score__value']

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -213,7 +213,7 @@ def test_docarray_inputs(make_flow, inputs):
 @pytest.mark.asyncio
 async def test_async_arank(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
-    r = await c.arank(inputs)
+    r = await c.arank(inputs if not callable(inputs) else inputs())
     assert '__loaded_by_CAS__' not in r[0].tags
     assert not r[0].blob
     assert not r[0].tensor

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -146,3 +146,50 @@ async def test_async_arank(make_flow, d):
     for v in rv:
         assert v is not None
         assert -1.0 <= v <= 1.0
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [
+            Document(text='A', matches=[Document(text='B'), Document(text='C')])
+            for _ in range(20)
+        ],
+        DocumentArray(
+            [
+                Document(text='A', matches=[Document(text='B'), Document(text='C')])
+                for _ in range(20)
+            ]
+        ),
+    ],
+)
+def test_docarray_preserve_original_order(make_flow, inputs):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    r = c.rank(inputs, batch_size=1)
+    assert isinstance(r, DocumentArray)
+    for i in range(len(inputs)):
+        assert inputs[i] is r[i]
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [
+            Document(text='A', matches=[Document(text='B'), Document(text='C')])
+            for _ in range(20)
+        ],
+        DocumentArray(
+            [
+                Document(text='A', matches=[Document(text='B'), Document(text='C')])
+                for _ in range(20)
+            ]
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_docarray_preserve_original_order(make_flow, inputs):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    r = await c.arank(inputs, batch_size=1)
+    assert isinstance(r, DocumentArray)
+    for i in range(len(inputs)):
+        assert inputs[i] is r[i]

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -71,36 +71,74 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
 
 
 @pytest.mark.parametrize(
-    'd',
+    'inputs',
     [
-        Document(
-            uri='https://docarray.jina.ai/_static/favicon.png',
-            matches=[Document(text='hello, world'), Document(text='goodbye, world')],
-        ),
-        Document(
-            text='hello, world',
-            matches=[
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+        [
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            ),
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            ),
+        ],
+        DocumentArray(
+            [
                 Document(
-                    uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    matches=[
+                        Document(text='hello, world'),
+                        Document(text='goodbye, world'),
+                    ],
                 ),
-            ],
+                Document(
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    matches=[
+                        Document(text='hello, world'),
+                        Document(text='goodbye, world'),
+                    ],
+                ),
+            ]
+        ),
+        lambda: (
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            )
+            for _ in range(10)
+        ),
+        DocumentArray(
+            [
+                Document(
+                    text='hello, world',
+                    matches=[
+                        Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                        Document(
+                            uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
+                        ),
+                    ],
+                )
+            ]
         ),
     ],
 )
-def test_docarray_inputs(make_flow, d):
+def test_docarray_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
-    r = c.rank([d])
-    assert r[0].content == d.content
-    assert r[0].matches.contents == d.matches.contents
-    assert '__loaded_by_CAS__' not in d.tags
-    assert not d.blob
-    assert not d.tensor
-    assert '__loaded_by_CAS__' not in d.matches[0].tags
-    assert not d.matches[0].blob
-    assert not d.matches[0].tensor
+    r = c.rank(inputs if not callable(inputs) else inputs())
+    assert '__loaded_by_CAS__' not in r[0].tags
+    assert not r[0].blob
+    assert not r[0].tensor
     assert isinstance(r, DocumentArray)
-    assert d is r[0]
     rv1 = r['@m', 'scores__clip_score__value']
     rv2 = r['@m', 'scores__clip_score_cosine__value']
     for v1, v2 in zip(rv1, rv2):
@@ -111,31 +149,75 @@ def test_docarray_inputs(make_flow, d):
 
 
 @pytest.mark.parametrize(
-    'd',
+    'inputs',
     [
-        Document(
-            uri='https://docarray.jina.ai/_static/favicon.png',
-            matches=[Document(text='hello, world'), Document(text='goodbye, world')],
-        ),
-        Document(
-            text='hello, world',
-            matches=[
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+        [
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            ),
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            ),
+        ],
+        DocumentArray(
+            [
                 Document(
-                    uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    matches=[
+                        Document(text='hello, world'),
+                        Document(text='goodbye, world'),
+                    ],
                 ),
-            ],
+                Document(
+                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    matches=[
+                        Document(text='hello, world'),
+                        Document(text='goodbye, world'),
+                    ],
+                ),
+            ]
+        ),
+        lambda: (
+            Document(
+                uri='https://docarray.jina.ai/_static/favicon.png',
+                matches=[
+                    Document(text='hello, world'),
+                    Document(text='goodbye, world'),
+                ],
+            )
+            for _ in range(10)
+        ),
+        DocumentArray(
+            [
+                Document(
+                    text='hello, world',
+                    matches=[
+                        Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                        Document(
+                            uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
+                        ),
+                    ],
+                )
+            ]
         ),
     ],
 )
 @pytest.mark.asyncio
-async def test_async_arank(make_flow, d):
+async def test_async_arank(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
-    r = await c.arank([d])
+    r = await c.arank(inputs)
+    assert '__loaded_by_CAS__' not in r[0].tags
+    assert not r[0].blob
+    assert not r[0].tensor
     assert isinstance(r, DocumentArray)
-    assert r[0].content == d.content
-    assert r[0].matches.contents == d.matches.contents
-    assert d is r[0]
     rv = r['@m', 'scores__clip_score__value']
     for v in rv:
         assert v is not None

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -152,13 +152,19 @@ async def test_async_arank(make_flow, d):
     'inputs',
     [
         [
-            Document(text='A', matches=[Document(text='B'), Document(text='C')])
-            for _ in range(20)
+            Document(
+                id=str(i), text='A', matches=[Document(text='B'), Document(text='C')]
+            )
+            for i in range(20)
         ],
         DocumentArray(
             [
-                Document(text='A', matches=[Document(text='B'), Document(text='C')])
-                for _ in range(20)
+                Document(
+                    id=str(i),
+                    text='A',
+                    matches=[Document(text='B'), Document(text='C')],
+                )
+                for i in range(20)
             ]
         ),
     ],
@@ -169,19 +175,26 @@ def test_docarray_preserve_original_order(make_flow, inputs):
     assert isinstance(r, DocumentArray)
     for i in range(len(inputs)):
         assert inputs[i] is r[i]
+        assert inputs[i].id == str(i)
 
 
 @pytest.mark.parametrize(
     'inputs',
     [
         [
-            Document(text='A', matches=[Document(text='B'), Document(text='C')])
-            for _ in range(20)
+            Document(
+                id=str(i), text='A', matches=[Document(text='B'), Document(text='C')]
+            )
+            for i in range(20)
         ],
         DocumentArray(
             [
-                Document(text='A', matches=[Document(text='B'), Document(text='C')])
-                for _ in range(20)
+                Document(
+                    id=str(i),
+                    text='A',
+                    matches=[Document(text='B'), Document(text='C')],
+                )
+                for i in range(20)
             ]
         ),
     ],
@@ -193,3 +206,4 @@ async def test_async_docarray_preserve_original_order(make_flow, inputs):
     assert isinstance(r, DocumentArray)
     for i in range(len(inputs)):
         assert inputs[i] is r[i]
+        assert inputs[i].id == str(i)

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -159,23 +159,9 @@ def test_docarray_inputs(make_flow, inputs):
                     Document(text='goodbye, world'),
                 ],
             ),
-            Document(
-                uri='https://docarray.jina.ai/_static/favicon.png',
-                matches=[
-                    Document(text='hello, world'),
-                    Document(text='goodbye, world'),
-                ],
-            ),
         ],
         DocumentArray(
             [
-                Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
-                    matches=[
-                        Document(text='hello, world'),
-                        Document(text='goodbye, world'),
-                    ],
-                ),
                 Document(
                     uri='https://docarray.jina.ai/_static/favicon.png',
                     matches=[
@@ -193,7 +179,7 @@ def test_docarray_inputs(make_flow, inputs):
                     Document(text='goodbye, world'),
                 ],
             )
-            for _ in range(10)
+            for _ in range(1)
         ),
         DocumentArray(
             [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -71,7 +71,7 @@ def test_server_download_not_regular_file(tmpdir):
         )
 
 
-def test_make_onnx_flow_wrong_name_path(port_generator):
+def test_make_onnx_flow_wrong_name_path():
     from clip_server.executors.clip_onnx import CLIPEncoder
 
     with pytest.raises(Exception):

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -76,10 +76,7 @@ def test_docarray_inputs(make_flow, inputs):
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
     assert r.embeddings.shape
-    assert '__created_by_CAS__' not in r[0].tags
-    assert '__loaded_by_CAS__' not in r[0].tags
     assert not r[0].tensor
-    assert not r[0].blob
     if hasattr(inputs, '__len__'):
         assert inputs[0] is r[0]
 
@@ -107,10 +104,7 @@ def test_docarray_preserve_original_inputs(make_flow, inputs):
     assert isinstance(r, DocumentArray)
     assert r.embeddings.shape
     assert r.contents == inputs.contents
-    assert '__created_by_CAS__' not in r[0].tags
-    assert '__loaded_by_CAS__' not in r[0].tags
     assert not r[0].tensor
-    assert not r[0].blob
     assert inputs[0] is r[0]
 
 
@@ -141,8 +135,6 @@ def test_docarray_traversal(make_flow, inputs):
     r1 = c.post(on='/', inputs=da, parameters={'traversal_paths': '@c'})
     assert isinstance(r1, DocumentArray)
     assert r1[0].chunks.embeddings.shape[0] == len(inputs)
-    assert '__created_by_CAS__' not in r1[0].tags
-    assert '__loaded_by_CAS__' not in r1[0].tags
     assert not r1[0].tensor
     assert not r1[0].blob
     assert not r1[0].chunks[0].tensor
@@ -151,8 +143,6 @@ def test_docarray_traversal(make_flow, inputs):
     r2 = c.post(on='/', inputs=da, parameters={'access_paths': '@c'})
     assert isinstance(r2, DocumentArray)
     assert r2[0].chunks.embeddings.shape[0] == len(inputs)
-    assert '__created_by_CAS__' not in r2[0].tags
-    assert '__loaded_by_CAS__' not in r2[0].tags
     assert not r2[0].tensor
     assert not r2[0].blob
     assert not r2[0].chunks[0].tensor

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -76,6 +76,8 @@ def test_docarray_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
+    if hasattr(inputs, '__len__'):
+        assert inputs[0] is r[0]
     assert r.embeddings.shape
     assert '__created_by_CAS__' not in r[0].tags
     assert '__loaded_by_CAS__' not in r[0].tags
@@ -104,6 +106,7 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
+    assert inputs[0] is r[0]
     assert r.embeddings.shape
     assert r.contents == inputs.contents
     assert '__created_by_CAS__' not in r[0].tags
@@ -130,14 +133,14 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
     ],
 )
 def test_docarray_traversal(make_flow, inputs, port_generator):
+    from jina import Client as _Client
+
     da = DocumentArray.empty(1)
     da[0].chunks = inputs
 
-    from jina import Client as _Client
-
     c = _Client(host=f'grpc://0.0.0.0', port=make_flow.port)
     r1 = c.post(on='/', inputs=da, parameters={'traversal_paths': '@c'})
-    r2 = c.post(on='/', inputs=da, parameters={'access_paths': '@c'})
+    assert isinstance(r1, DocumentArray)
     assert r1[0].chunks.embeddings.shape[0] == len(inputs)
     assert '__created_by_CAS__' not in r1[0].tags
     assert '__loaded_by_CAS__' not in r1[0].tags
@@ -145,6 +148,9 @@ def test_docarray_traversal(make_flow, inputs, port_generator):
     assert not r1[0].blob
     assert not r1[0].chunks[0].tensor
     assert not r1[0].chunks[0].blob
+
+    r2 = c.post(on='/', inputs=da, parameters={'access_paths': '@c'})
+    assert isinstance(r2, DocumentArray)
     assert r2[0].chunks.embeddings.shape[0] == len(inputs)
     assert '__created_by_CAS__' not in r2[0].tags
     assert '__loaded_by_CAS__' not in r2[0].tags

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -43,7 +43,6 @@ def test_protocols(port_generator, protocol, jit, pytestconfig):
 def test_plain_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
-
     assert (
         r.shape[0] == len(list(inputs)) if not callable(inputs) else len(list(inputs()))
     )
@@ -76,13 +75,13 @@ def test_docarray_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
-    if hasattr(inputs, '__len__'):
-        assert inputs[0] is r[0]
     assert r.embeddings.shape
     assert '__created_by_CAS__' not in r[0].tags
     assert '__loaded_by_CAS__' not in r[0].tags
     assert not r[0].tensor
     assert not r[0].blob
+    if hasattr(inputs, '__len__'):
+        assert inputs[0] is r[0]
 
 
 @pytest.mark.parametrize(
@@ -106,13 +105,13 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
-    assert inputs[0] is r[0]
     assert r.embeddings.shape
     assert r.contents == inputs.contents
     assert '__created_by_CAS__' not in r[0].tags
     assert '__loaded_by_CAS__' not in r[0].tags
     assert not r[0].tensor
     assert not r[0].blob
+    assert inputs[0] is r[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -162,8 +162,8 @@ def test_docarray_traversal(make_flow, inputs):
 @pytest.mark.parametrize(
     'inputs',
     [
-        [Document(text='hello, world') for _ in range(20)],
-        DocumentArray([Document(text='hello, world') for _ in range(20)]),
+        [Document(id=str(i), text='hello, world') for i in range(20)],
+        DocumentArray([Document(id=str(i), text='hello, world') for i in range(20)]),
     ],
 )
 def test_docarray_preserve_original_order(make_flow, inputs):
@@ -172,3 +172,4 @@ def test_docarray_preserve_original_order(make_flow, inputs):
     assert isinstance(r, DocumentArray)
     for i in range(len(inputs)):
         assert inputs[i] is r[i]
+        assert inputs[i].id == str(i)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -40,7 +40,7 @@ def test_protocols(port_generator, protocol, jit, pytestconfig):
         ],
     ],
 )
-def test_plain_inputs(make_flow, inputs, port_generator):
+def test_plain_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert (
@@ -71,7 +71,7 @@ def test_plain_inputs(make_flow, inputs, port_generator):
         ),
     ],
 )
-def test_docarray_inputs(make_flow, inputs, port_generator):
+def test_docarray_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
@@ -101,7 +101,7 @@ def test_docarray_inputs(make_flow, inputs, port_generator):
         ),
     ],
 )
-def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
+def test_docarray_preserve_original_inputs(make_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
@@ -131,7 +131,7 @@ def test_docarray_preserve_original_inputs(make_flow, inputs, port_generator):
         ),
     ],
 )
-def test_docarray_traversal(make_flow, inputs, port_generator):
+def test_docarray_traversal(make_flow, inputs):
     from jina import Client as _Client
 
     da = DocumentArray.empty(1)
@@ -157,3 +157,18 @@ def test_docarray_traversal(make_flow, inputs, port_generator):
     assert not r2[0].blob
     assert not r2[0].chunks[0].tensor
     assert not r2[0].chunks[0].blob
+
+
+@pytest.mark.parametrize(
+    'inputs',
+    [
+        [Document(text='hello, world') for _ in range(20)],
+        DocumentArray([Document(text='hello, world') for _ in range(20)]),
+    ],
+)
+def test_docarray_preserve_original_order(make_flow, inputs):
+    c = Client(server=f'grpc://0.0.0.0:{make_flow.port}')
+    r = c.encode(inputs if not callable(inputs) else inputs(), batch_size=1)
+    assert isinstance(r, DocumentArray)
+    for i in range(len(inputs)):
+        assert inputs[i] is r[i]

--- a/tests/test_tensorrt.py
+++ b/tests/test_tensorrt.py
@@ -36,8 +36,9 @@ def test_docarray_inputs(make_trt_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_trt_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
-    assert inputs[0] is r[0]
     assert r.embeddings.shape
+    if hasattr(inputs, '__len__'):
+        assert inputs[0] is r[0]
 
 
 @pytest.mark.gpu

--- a/tests/test_tensorrt.py
+++ b/tests/test_tensorrt.py
@@ -36,6 +36,7 @@ def test_docarray_inputs(make_trt_flow, inputs):
     c = Client(server=f'grpc://0.0.0.0:{make_trt_flow.port}')
     r = c.encode(inputs if not callable(inputs) else inputs())
     assert isinstance(r, DocumentArray)
+    assert inputs[0] is r[0]
     assert r.embeddings.shape
 
 
@@ -63,6 +64,7 @@ async def test_async_arank(make_trt_flow, d):
     c = Client(server=f'grpc://0.0.0.0:{make_trt_flow.port}')
     r = await c.arank([d])
     assert isinstance(r, DocumentArray)
+    assert d is r[0]
     rv = r['@m', 'scores__clip_score__value']
     for v in rv:
         assert v is not None


### PR DESCRIPTION
Please merge https://github.com/jina-ai/clip-as-service/pull/815 first

This PR adds a `drop_image_content` parameter to `clip_server`. If set, it will remove the input image contents (blob and tensor) after encoding to save space. This is especially beneficial for saving bandwidth.