### PR TITLE
feat: support B/32, L/14, H/14, and g/14 trained on LAION-2B

### DIFF
--- a/docs/user-guides/server.md
+++ b/docs/user-guides/server.md
@@ -196,7 +196,6 @@ Basically, each YAML file defines a [Jina Flow](https://docs.jina.ai/fundamental
 Looking at the YAML file again, we can put it into three subsections as below:
 
 
-
 ````{tab} CLIP model config
 
 ```{code-block} yaml

--- a/docs/user-guides/server.md
+++ b/docs/user-guides/server.md
@@ -79,6 +79,7 @@ Please also note that **different models give different sizes of output dimensio
 | ViT-B-32::laion2b_e16                 | ✅       | ✅    | ✅        | 512              | 577             | 2.93                | 1.40                 |
 | ViT-B-32::laion400m_e31               | ✅       | ✅    | ✅        | 512              | 577             | 2.93                | 1.40                 |
 | ViT-B-32::laion400m_e32               | ✅       | ✅    | ✅        | 512              | 577             | 2.94                | 1.40                 |
+| ViT-B-32::laion2B-s34B-b79K           | ✅       | ✅    | ❌        | 512              | 577             | 2.94                | 1.40                 |
 | ViT-B-16::openai                      | ✅       | ✅    | ✅        | 512              | 335             | 3.20                | 1.44                 |
 | ViT-B-16::laion400m_e31               | ✅       | ✅    | ✅        | 512              | 571             | 2.93                | 1.44                 |
 | ViT-B-16::laion400m_e32               | ✅       | ✅    | ✅        | 512              | 571             | 2.94                | 1.44                 |
@@ -87,7 +88,10 @@ Please also note that **different models give different sizes of output dimensio
 | ViT-L-14::openai                      | ✅       | ✅    | ❌        | 768              | 890             | 3.66                | 2.04                 |
 | ViT-L-14::laion400m_e31               | ✅       | ✅    | ❌        | 768              | 1631            | 3.43                | 2.03                 |
 | ViT-L-14::laion400m_e32               | ✅       | ✅    | ❌        | 768              | 1631            | 3.42                | 2.03                 |
+| ViT-L-14::laion2B-s32B-b82K           | ✅       | ✅    | ❌        | 768              | 1631            | 3.43                | 2.03                 |
 | ViT-L-14-336::openai                  | ✅       | ✅    | ❌        | 768              | 891             | 3.74                | 2.23                 |
+| ViT-H-14::laion2B-s32B-b79K           | ✅       | 🚧   | ❌        | 1024             | 3762            | 4.45                | 3.26                 |
+| ViT-g-14::laion2B-s12B-b42K           | ✅       | 🚧   | ❌        | 1024             | 5214            | 5.16                | 4.00                 |
 | M-CLIP/XLM-Roberta-Large-Vit-B-32     | ✅       | 🚧   | 🚧       | 512              | 4284            | 5.37                | 1.68                 |
 | M-CLIP/XLM-Roberta-Large-Vit-L-14     | ✅       | 🚧   | ❌        | 768              | 4293            | 4.30                | 4.97                 |
 | M-CLIP/XLM-Roberta-Large-Vit-B-16Plus | ✅       | 🚧   | 🚧       | 640              | 4293            | 4.30                | 4.13                 |

--- a/server/clip_server/model/clip_onnx.py
+++ b/server/clip_server/model/clip_onnx.py
@@ -117,14 +117,6 @@ _MODELS = {
         ('ViT-L-14@336px/textual.onnx', '78fab479f136403eed0db46f3e9e7ed2'),
         ('ViT-L-14@336px/visual.onnx', 'f3b1f5d55ca08d43d749e11f7e4ba27e'),
     ),
-    'ViT-H-14::laion2B-s32B-b79K': (
-        ('ViT-H-14-laion2B-s32B-b79K/textual.onnx', '41e73c0c871d0e8e5d5e236f917f1ec3'),
-        ('ViT-H-14-laion2B-s32B-b79K/visual.onnx', '9c8213d09e2f8f35f684b468b0b0df17'),
-    ),
-    'ViT-g-14::laion2B-s12B-b42K': (
-        ('ViT-g-14-laion2B-s12B-b42K/textual.onnx', 'e597b7ab4414ecd92f715d47e79a033f'),
-        ('ViT-g-14-laion2B-s12B-b42K/visual.onnx', 'd51a6d197542793f1053f843baf6266c'),
-    ),
     # older version name format
     'RN50': (
         ('RN50/textual.onnx', '722418bfe47a1f5c79d1f44884bb3103'),

--- a/server/clip_server/model/clip_onnx.py
+++ b/server/clip_server/model/clip_onnx.py
@@ -61,6 +61,10 @@ _MODELS = {
         ('ViT-B-32-laion400m_e32/textual.onnx', '93284915937ba42a2b52ae8d3e5283a0'),
         ('ViT-B-32-laion400m_e32/visual.onnx', 'db220821a31fe9795fd8c2ba419078c5'),
     ),
+    'ViT-B-32::laion2B-s34B-b79K': (
+        ('ViT-B-32-laion2B-s34B-b79K/textual.onnx', '84af5ae53da56464c76e67fe50fddbe9'),
+        ('ViT-B-32-laion2B-s34B-b79K/visual.onnx', 'a2d4cbd1cf2632cd09ffce9b40bfd8bd'),
+    ),
     'ViT-B-16::openai': (
         ('ViT-B-16/textual.onnx', '6f0976629a446f95c0c8767658f12ebe'),
         ('ViT-B-16/visual.onnx', 'd5c03bfeef1abbd9bede54a8f6e1eaad'),
@@ -105,9 +109,21 @@ _MODELS = {
         ('ViT-L-14-laion400m_e32/textual.onnx', '8ba5b76ba71992923470c0261b10a67c'),
         ('ViT-L-14-laion400m_e32/visual.onnx', '49db3ba92bd816001e932530ad92d76c'),
     ),
+    'ViT-L-14::laion2B-s32B-b82K': (
+        ('ViT-L-14-laion2B-s32B-b82K/textual.onnx', 'da36a6cbed4f56abf576fdea8b6fe2ee'),
+        ('ViT-L-14-laion2B-s32B-b82K/visual.onnx', '1e337a190abba6a8650237dfae4740b7'),
+    ),
     'ViT-L-14-336::openai': (
         ('ViT-L-14@336px/textual.onnx', '78fab479f136403eed0db46f3e9e7ed2'),
         ('ViT-L-14@336px/visual.onnx', 'f3b1f5d55ca08d43d749e11f7e4ba27e'),
+    ),
+    'ViT-H-14::laion2B-s32B-b79K': (
+        ('ViT-H-14-laion2B-s32B-b79K/textual.onnx', '41e73c0c871d0e8e5d5e236f917f1ec3'),
+        ('ViT-H-14-laion2B-s32B-b79K/visual.onnx', '9c8213d09e2f8f35f684b468b0b0df17'),
+    ),
+    'ViT-g-14::laion2B-s12B-b42K': (
+        ('ViT-g-14-laion2B-s12B-b42K/textual.onnx', 'e597b7ab4414ecd92f715d47e79a033f'),
+        ('ViT-g-14-laion2B-s12B-b42K/visual.onnx', 'd51a6d197542793f1053f843baf6266c'),
     ),
     # older version name format
     'RN50': (

--- a/server/clip_server/model/pretrained_models.py
+++ b/server/clip_server/model/pretrained_models.py
@@ -27,6 +27,7 @@ _OPENCLIP_MODELS = {
         'ViT-B-32-laion400m_e32.pt',
         '359e0dba4a419f175599ee0c63a110d8',
     ),
+    'ViT-B-32::laion2B-s34B-b79K': ('ViT-B-32-laion2B-s34B-b79K.bin', None),
     'ViT-B-16::openai': ('ViT-B-16.pt', '44c3d804ecac03d9545ac1a3adbca3a6'),
     'ViT-B-16::laion400m_e31': (
         'ViT-B-16-laion400m_e31.pt',
@@ -53,7 +54,10 @@ _OPENCLIP_MODELS = {
         'ViT-L-14-laion400m_e32.pt',
         'a76cde1bc744ca38c6036b920c847a89',
     ),
+    'ViT-L-14::laion2B-s32B-b82K': ('ViT-L-14-laion2B-s32B-b82K.bin', None),
     'ViT-L-14-336::openai': ('ViT-L-14-336px.pt', 'b311058cae50cb10fbfa2a44231c9473'),
+    'ViT-H-14::laion2B-s32B-b79K': ('ViT-H-14-laion2B-s32B-b79K.bin', None),
+    'ViT-g-14::laion2B-s12B-b42K': ('ViT-g-14-laion2B-s12B-b42K.bin', None),
     # older version name format
     'RN50': ('RN50.pt', '9140964eaaf9f68c95aa8df6ca13777c'),
     'RN101': ('RN101.pt', 'fa9d5f64ebf152bc56a18db245071014'),
@@ -81,10 +85,12 @@ _VISUAL_MODEL_IMAGE_SIZE = {
     'RN50x64': 448,
     'ViT-B-32': 224,
     'ViT-B-16': 224,
+    'Vit-B-16Plus': 240,
     'ViT-B-16-plus-240': 240,
     'ViT-L-14': 224,
     'ViT-L-14-336': 336,
-    'Vit-B-16Plus': 240,
+    'ViT-H-14': 224,
+    'ViT-g-14': 224,
 }
 
 

--- a/server/clip_server/model/pretrained_models.py
+++ b/server/clip_server/model/pretrained_models.py
@@ -27,7 +27,10 @@ _OPENCLIP_MODELS = {
         'ViT-B-32-laion400m_e32.pt',
         '359e0dba4a419f175599ee0c63a110d8',
     ),
-    'ViT-B-32::laion2B-s34B-b79K': ('ViT-B-32-laion2B-s34B-b79K.bin', None),
+    'ViT-B-32::laion2B-s34B-b79K': (
+        'ViT-B-32-laion2B-s34B-b79K.bin',
+        '2fc036aea9cd7306f5ce7ce6abb8d0bf',
+    ),
     'ViT-B-16::openai': ('ViT-B-16.pt', '44c3d804ecac03d9545ac1a3adbca3a6'),
     'ViT-B-16::laion400m_e31': (
         'ViT-B-16-laion400m_e31.pt',
@@ -54,10 +57,19 @@ _OPENCLIP_MODELS = {
         'ViT-L-14-laion400m_e32.pt',
         'a76cde1bc744ca38c6036b920c847a89',
     ),
-    'ViT-L-14::laion2B-s32B-b82K': ('ViT-L-14-laion2B-s32B-b82K.bin', None),
+    'ViT-L-14::laion2B-s32B-b82K': (
+        'ViT-L-14-laion2B-s32B-b82K.bin',
+        '4d2275fc7b2d7ee9db174f9b57ddecbd',
+    ),
     'ViT-L-14-336::openai': ('ViT-L-14-336px.pt', 'b311058cae50cb10fbfa2a44231c9473'),
-    'ViT-H-14::laion2B-s32B-b79K': ('ViT-H-14-laion2B-s32B-b79K.bin', None),
-    'ViT-g-14::laion2B-s12B-b42K': ('ViT-g-14-laion2B-s12B-b42K.bin', None),
+    'ViT-H-14::laion2B-s32B-b79K': (
+        'ViT-H-14-laion2B-s32B-b79K.bin',
+        '2aa6c46521b165a0daeb8cdc6668c7d3',
+    ),
+    'ViT-g-14::laion2B-s12B-b42K': (
+        'ViT-g-14-laion2B-s12B-b42K.bin',
+        '3bf99353f6f1829faac0bb155be4382a',
+    ),
     # older version name format
     'RN50': ('RN50.pt', '9140964eaaf9f68c95aa8df6ca13777c'),
     'RN101': ('RN101.pt', 'fa9d5f64ebf152bc56a18db245071014'),

--- a/server/clip_server/onnx-flow.yml
+++ b/server/clip_server/onnx-flow.yml
@@ -9,4 +9,5 @@ executors:
       metas:
         py_modules:
           - clip_server.executors.clip_onnx
+    timeout_ready: 3000000
     replicas: 1

--- a/server/clip_server/torch-flow.yml
+++ b/server/clip_server/torch-flow.yml
@@ -9,4 +9,5 @@ executors:
       metas:
         py_modules:
           - clip_server.executors.clip_torch
+    timeout_ready: 3000000
     replicas: 1


### PR DESCRIPTION
This pr supports 4 new clip models introduced by https://laion.ai/blog/large-openclip/

- ViT-B-32::laion2B-s34B-b79K (PyTorch+ONNX)
- ViT-L-14::laion2B-s32B-b82K (PyTorch+ONNX)
- ViT-H-14::laion2B-s32B-b79K (PyTorch)
- ViT-g-14::laion2B-s12B-b42K (PyTorch)

It also sets timeout to 30 min in torch and onnx runtime since we have larger model files now