### PR TITLE
chore: use open clip naming convention for model names

### DIFF
--- a/docs/user-guides/server.md
+++ b/docs/user-guides/server.md
@@ -79,7 +79,7 @@ Please also note that **different models give different sizes of output dimensio
 | ViT-B-32::laion2b_e16                 | ✅       | ✅    | ✅        | 512              | 577             | 2.93                | 1.40                 |
 | ViT-B-32::laion400m_e31               | ✅       | ✅    | ✅        | 512              | 577             | 2.93                | 1.40                 |
 | ViT-B-32::laion400m_e32               | ✅       | ✅    | ✅        | 512              | 577             | 2.94                | 1.40                 |
-| ViT-B-32::laion2B-s34B-b79K           | ✅       | ✅    | ❌        | 512              | 577             | 2.94                | 1.40                 |
+| ViT-B-32::laion2b-s34b-b79k           | ✅       | ✅    | ❌        | 512              | 577             | 2.94                | 1.40                 |
 | ViT-B-16::openai                      | ✅       | ✅    | ✅        | 512              | 335             | 3.20                | 1.44                 |
 | ViT-B-16::laion400m_e31               | ✅       | ✅    | ✅        | 512              | 571             | 2.93                | 1.44                 |
 | ViT-B-16::laion400m_e32               | ✅       | ✅    | ✅        | 512              | 571             | 2.94                | 1.44                 |
@@ -88,10 +88,10 @@ Please also note that **different models give different sizes of output dimensio
 | ViT-L-14::openai                      | ✅       | ✅    | ❌        | 768              | 890             | 3.66                | 2.04                 |
 | ViT-L-14::laion400m_e31               | ✅       | ✅    | ❌        | 768              | 1631            | 3.43                | 2.03                 |
 | ViT-L-14::laion400m_e32               | ✅       | ✅    | ❌        | 768              | 1631            | 3.42                | 2.03                 |
-| ViT-L-14::laion2B-s32B-b82K           | ✅       | ✅    | ❌        | 768              | 1631            | 3.43                | 2.03                 |
+| ViT-L-14::laion2b-s32b-b82k           | ✅       | ✅    | ❌        | 768              | 1631            | 3.43                | 2.03                 |
 | ViT-L-14-336::openai                  | ✅       | ✅    | ❌        | 768              | 891             | 3.74                | 2.23                 |
-| ViT-H-14::laion2B-s32B-b79K           | ✅       | ✅    | ❌        | 1024             | 3762            | 4.45                | 3.26                 |
-| ViT-g-14::laion2B-s12B-b42K           | ✅       | ✅    | ❌        | 1024             | 5214            | 5.16                | 4.00                 |
+| ViT-H-14::laion2b-s32b-b79k           | ✅       | ✅    | ❌        | 1024             | 3762            | 4.45                | 3.26                 |
+| ViT-g-14::laion2b-s12b-b42k           | ✅       | ✅    | ❌        | 1024             | 5214            | 5.16                | 4.00                 |
 | M-CLIP/LABSE-Vit-L-14                 | ✅       | ✅    | ❌        | 768              | 3609            | 4.30                | 4.70                 |
 | M-CLIP/XLM-Roberta-Large-Vit-B-32     | ✅       | ✅    | 🚧       | 512              | 4284            | 5.37                | 1.68                 |
 | M-CLIP/XLM-Roberta-Large-Vit-B-16Plus | ✅       | ✅    | 🚧       | 640              | 4293            | 4.30                | 4.13                 |

--- a/server/clip_server/model/clip_onnx.py
+++ b/server/clip_server/model/clip_onnx.py
@@ -61,9 +61,9 @@ _MODELS = {
         ('ViT-B-32-laion400m_e32/textual.onnx', '93284915937ba42a2b52ae8d3e5283a0'),
         ('ViT-B-32-laion400m_e32/visual.onnx', 'db220821a31fe9795fd8c2ba419078c5'),
     ),
-    'ViT-B-32::laion2B-s34B-b79K': (
-        ('ViT-B-32-laion2B-s34B-b79K/textual.onnx', '84af5ae53da56464c76e67fe50fddbe9'),
-        ('ViT-B-32-laion2B-s34B-b79K/visual.onnx', 'a2d4cbd1cf2632cd09ffce9b40bfd8bd'),
+    'ViT-B-32::laion2b-s34b-b79k': (
+        ('ViT-B-32-laion2b-s34b-b79k/textual.onnx', '84af5ae53da56464c76e67fe50fddbe9'),
+        ('ViT-B-32-laion2b-s34b-b79k/visual.onnx', 'a2d4cbd1cf2632cd09ffce9b40bfd8bd'),
     ),
     'ViT-B-16::openai': (
         ('ViT-B-16/textual.onnx', '6f0976629a446f95c0c8767658f12ebe'),
@@ -109,21 +109,21 @@ _MODELS = {
         ('ViT-L-14-laion400m_e32/textual.onnx', '8ba5b76ba71992923470c0261b10a67c'),
         ('ViT-L-14-laion400m_e32/visual.onnx', '49db3ba92bd816001e932530ad92d76c'),
     ),
-    'ViT-L-14::laion2B-s32B-b82K': (
-        ('ViT-L-14-laion2B-s32B-b82K/textual.onnx', 'da36a6cbed4f56abf576fdea8b6fe2ee'),
-        ('ViT-L-14-laion2B-s32B-b82K/visual.onnx', '1e337a190abba6a8650237dfae4740b7'),
+    'ViT-L-14::laion2b-s32b-b82k': (
+        ('ViT-L-14-laion2b-s32b-b82k/textual.onnx', 'da36a6cbed4f56abf576fdea8b6fe2ee'),
+        ('ViT-L-14-laion2b-s32b-b82k/visual.onnx', '1e337a190abba6a8650237dfae4740b7'),
     ),
     'ViT-L-14-336::openai': (
         ('ViT-L-14@336px/textual.onnx', '78fab479f136403eed0db46f3e9e7ed2'),
         ('ViT-L-14@336px/visual.onnx', 'f3b1f5d55ca08d43d749e11f7e4ba27e'),
     ),
-    'ViT-H-14::laion2B-s32B-b79K': (
-        ('ViT-H-14-laion2B-s32B-b79K/textual.onnx', '41e73c0c871d0e8e5d5e236f917f1ec3'),
-        ('ViT-H-14-laion2B-s32B-b79K/visual.zip', '38151ea5985d73de94520efef38db4e7'),
+    'ViT-H-14::laion2b-s32b-b79k': (
+        ('ViT-H-14-laion2b-s32b-b79k/textual.onnx', '41e73c0c871d0e8e5d5e236f917f1ec3'),
+        ('ViT-H-14-laion2b-s32b-b79k/visual.zip', '38151ea5985d73de94520efef38db4e7'),
     ),
-    'ViT-g-14::laion2B-s12B-b42K': (
-        ('ViT-g-14-laion2B-s12B-b42K/textual.onnx', 'e597b7ab4414ecd92f715d47e79a033f'),
-        ('ViT-g-14-laion2B-s12B-b42K/visual.zip', '6d0ac4329de9b02474f4752a5d16ba82'),
+    'ViT-g-14::laion2b-s12b-b42k': (
+        ('ViT-g-14-laion2b-s12b-b42k/textual.onnx', 'e597b7ab4414ecd92f715d47e79a033f'),
+        ('ViT-g-14-laion2b-s12b-b42k/visual.zip', '6d0ac4329de9b02474f4752a5d16ba82'),
     ),
     # older version name format
     'RN50': (

--- a/server/clip_server/model/pretrained_models.py
+++ b/server/clip_server/model/pretrained_models.py
@@ -27,8 +27,8 @@ _OPENCLIP_MODELS = {
         'ViT-B-32-laion400m_e32.pt',
         '359e0dba4a419f175599ee0c63a110d8',
     ),
-    'ViT-B-32::laion2B-s34B-b79K': (
-        'ViT-B-32-laion2B-s34B-b79K.bin',
+    'ViT-B-32::laion2b-s34b-b79k': (
+        'ViT-B-32-laion2b-s34b-b79k.bin',
         '2fc036aea9cd7306f5ce7ce6abb8d0bf',
     ),
     'ViT-B-16::openai': ('ViT-B-16.pt', '44c3d804ecac03d9545ac1a3adbca3a6'),
@@ -57,17 +57,17 @@ _OPENCLIP_MODELS = {
         'ViT-L-14-laion400m_e32.pt',
         'a76cde1bc744ca38c6036b920c847a89',
     ),
-    'ViT-L-14::laion2B-s32B-b82K': (
-        'ViT-L-14-laion2B-s32B-b82K.bin',
+    'ViT-L-14::laion2b-s32b-b82k': (
+        'ViT-L-14-laion2b-s32b-b82k.bin',
         '4d2275fc7b2d7ee9db174f9b57ddecbd',
     ),
     'ViT-L-14-336::openai': ('ViT-L-14-336px.pt', 'b311058cae50cb10fbfa2a44231c9473'),
-    'ViT-H-14::laion2B-s32B-b79K': (
-        'ViT-H-14-laion2B-s32B-b79K.bin',
+    'ViT-H-14::laion2b-s32b-b79k': (
+        'ViT-H-14-laion2b-s32b-b79k.bin',
         '2aa6c46521b165a0daeb8cdc6668c7d3',
     ),
-    'ViT-g-14::laion2B-s12B-b42K': (
-        'ViT-g-14-laion2B-s12B-b42K.bin',
+    'ViT-g-14::laion2b-s12b-b42k': (
+        'ViT-g-14-laion2b-s12b-b42k.bin',
         '3bf99353f6f1829faac0bb155be4382a',
     ),
     # older version name format

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -22,7 +22,7 @@ def test_torch_model(name, model_cls):
     'name',
     [
         'RN50::openai',
-        'ViT-H-14::laion2B-s32B-b79K',
+        'ViT-H-14::laion2b-s32b-b79k',
         'M-CLIP/LABSE-Vit-L-14',
     ],
 )


### PR DESCRIPTION
This pr adapts the naming convention of open clip to give a consistent list of model names. This can reduce confusion for users.
The S3 storage is also updated.

What is the reason for old names?

- Open clip hosts these models on HF Hub, and these are the names listed on hub.

Why new names?

- We want to give users a consistent experience dealing with [open clip model names](https://github.com/mlfoundations/open_clip#pretrained-model-interface). 

Model affected:

- ViT-B-32::laion2B-s34B-b79K -> ViT-B-32::laion2b-s34b-b79k
- ViT-L-14::laion2B-s32B-b82K -> ViT-L-14::laion2b-s32b-b82k
- ViT-H-14::laion2B-s32B-b79K -> ViT-H-14::laion2b-s32b-b79k
- ViT-g-14::laion2B-s12B-b42K -> ViT-g-14::laion2b-s12b-b42k