### PR TITLE
chore: change hub url from hub.jina.ai to cloud.jina.ai

### DIFF
--- a/.github/README-exec/torch.readme.md
+++ b/.github/README-exec/torch.readme.md
@@ -8,7 +8,7 @@ The introduction of the CLIP model [can be found here](https://openai.com/blog/c
 - ⚡ **Efficiency**: Faster CLIP model inference on CPU and GPU via leveraging the best practices. 
 - 📈 **Observability**: Monitoring the serving via Prometheus and Grafana (see [Usage Guide](https://docs.jina.ai/how-to/monitoring/#deploying-locally)).
 
-With advances of ONNX runtime, you can use `CLIPOnnxEncoder` (see [link](https://hub.jina.ai/executor/2a7auwg2)) instead to achieve **3x** model inference speed up.   
+With advances of ONNX runtime, you can use `CLIPOnnxEncoder` (see [link](https://cloud.jina.ai/executor/2a7auwg2)) instead to achieve **3x** model inference speed up.   
 
 ## Model support
 

--- a/docs/hosting/on-jcloud.md
+++ b/docs/hosting/on-jcloud.md
@@ -28,7 +28,7 @@ executors:
 `port` is unnecessary here as JCloud will assign a new hostname and port for any deployed service. 
 ```
 
-Executors must start with `jinahub+docker://` as it is required by JCloud. We currently provide containerized executors [`jinahub+docker://CLIPTorchEncoder`](https://hub.jina.ai/executor/gzpbl8jh) and [`jinahub+docker://CLIPOnnxEncoder`](https://hub.jina.ai/executor/2a7auwg2) on Jina Hub. They are automatically synced on the new release of `clip_server` module. 
+Executors must start with `jinahub+docker://` as it is required by JCloud. We currently provide containerized executors [`jinahub+docker://CLIPTorchEncoder`](https://cloud.jina.ai/executor/gzpbl8jh) and [`jinahub+docker://CLIPOnnxEncoder`](https://cloud.jina.ai/executor/2a7auwg2) on Jina Hub. They are automatically synced on the new release of `clip_server` module. 
 
 To enable GPU on JCloud, you need to configure it in the YAML file and use prebuilt docker GPU images. For example,
 
@@ -43,7 +43,7 @@ executors:
 
 Please refer [here](https://docs.jina.ai/fundamentals/jcloud/yaml-spec/#gpu) for more details on using GPU in JCloud.
 Notice that you must specify a docker image GPU tag for your executor to utilize the GPU. For example `latest-gpu`. 
-See the 'Tag' section in [CLIPTorchEncoder](https://hub.jina.ai/executor/gzpbl8jh) and [CLIPOnnxEncoder](https://hub.jina.ai/executor/2a7auwg2) for docker image GPU tags.
+See the 'Tag' section in [CLIPTorchEncoder](https://cloud.jina.ai/executor/gzpbl8jh) and [CLIPOnnxEncoder](https://cloud.jina.ai/executor/2a7auwg2) for docker image GPU tags.
 
 To deploy,
 


### PR DESCRIPTION
Change according to https://jinaai.slack.com/archives/C046ZPCJ951/p1666606756311729
Links are tested