### PR TITLE
feat: allow custom callback in clip_client

### DIFF
--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -232,6 +232,12 @@ class Client:
     @staticmethod
     def _unboxed_result(results: Optional['DocumentArray'] = None, unbox: bool = False):
         if results is not None:
+            if results.embeddings is None:
+                raise ValueError(
+                    'Empty embedding returned from the server. '
+                    'This often due to a mis-config of the server, '
+                    'restarting the server or changing the serving port number often solves the problem'
+                )
             return results.embeddings if unbox else results
 
     @overload

--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -336,7 +336,8 @@ class Client:
                 parameters=parameters,
             )
 
-        return self._unboxed_result(results, isinstance(content, list))
+        unbox = hasattr(content, '__len__') and isinstance(content[0], str)
+        return self._unboxed_result(results, unbox)
 
     @overload
     async def aencode(
@@ -404,7 +405,8 @@ class Client:
             ):
                 continue
 
-        return self._unboxed_result(results, isinstance(content, list))
+        unbox = hasattr(content, '__len__') and isinstance(content[0], str)
+        return self._unboxed_result(results, unbox)
 
     def _iter_rank_docs(
         self, content, results: Optional['DocumentArray'] = None, source='matches'

--- a/docs/user-guides/client.md
+++ b/docs/user-guides/client.md
@@ -473,6 +473,19 @@ for d in big_list:
 This is extremely slow as only one document is encoded at a time, it is a bad utilization of the network and not leveraging any duplex streaming.
 ````
 
+### Custom callback
+
+`clip_client` by default collects all the results and returns them to users. However, if you want to process the results on-the-fly, you can also pass a callback function when sending the request. For example, you can use the callback to save the results to a database, or render the results to a webpage. Specifically, you can specify any of the three callback functions: `on_done`, `on_error`, and `on_always`.
+
+- `on_done` is executed while streaming, after successful completion of each request
+- `on_error` is executed while streaming, whenever an error occurs in each request
+- `on_always` is always performed while streaming, no matter the success or failure of each request
+
+Note that these callbacks only work for requests (and failures) inside the stream. For `on_error`, if the failure is due to an error happening outside of streaming, then it will not be triggered. For example, a `SIGKILL` from the client OS during the handling of the request, or a networking issue, will not trigger the callback. Learn more about [handling exceptions in `on_error`](https://docs.jina.ai/fundamentals/client/client/#handle-exceptions-in-callbacks).
+
+Callback functions in expect a `Response` of the type DataRequest, which contains resulting Documents, parameters, and other information. Learn more about [handling `DataRequest` in callbacks](https://docs.jina.ai/fundamentals/client/client/#handle-datarequest-in-callbacks).
+
+
 ### Client parallelism
 
 In case you instanciate a `clip_client` object using the `grpc` protocol, keep in mind that `grpc` clients cannot be used in a multi-threaded environment (check [this gRPC issue](https://github.com/grpc/grpc/issues/25364) for reference).

--- a/docs/user-guides/client.md
+++ b/docs/user-guides/client.md
@@ -483,7 +483,7 @@ This is extremely slow as only one document is encoded at a time, it is a bad ut
 
 Note that these callbacks only work for requests (and failures) inside the stream. For `on_error`, if the failure is due to an error happening outside of streaming, then it will not be triggered. For example, a `SIGKILL` from the client OS during the handling of the request, or a networking issue, will not trigger the callback. Learn more about [handling exceptions in `on_error`](https://docs.jina.ai/fundamentals/client/client/#handle-exceptions-in-callbacks).
 
-Callback functions in expect a `Response` of the type DataRequest, which contains resulting Documents, parameters, and other information. Learn more about [handling `DataRequest` in callbacks](https://docs.jina.ai/fundamentals/client/client/#handle-datarequest-in-callbacks).
+Callback functions take a `Response` of the type DataRequest, which contains resulting Documents, parameters, and other information. Learn more about [handling `DataRequest` in callbacks](https://docs.jina.ai/fundamentals/client/client/#handle-datarequest-in-callbacks).
 
 In the following example, we will use `on_done` to save the results to a database. We use a simple `dict` to simulate the database. The error is saved to log file using `on_error`. `on_always` will print the number of documents processed in each request.
 

--- a/docs/user-guides/client.md
+++ b/docs/user-guides/client.md
@@ -485,6 +485,37 @@ Note that these callbacks only work for requests (and failures) inside the strea
 
 Callback functions in expect a `Response` of the type DataRequest, which contains resulting Documents, parameters, and other information. Learn more about [handling `DataRequest` in callbacks](https://docs.jina.ai/fundamentals/client/client/#handle-datarequest-in-callbacks).
 
+In the following example, we will use `on_done` to save the results to a database. We use a simple `dict` to simulate the database. The error is saved to log file using `on_error`. `on_always` will print the number of documents processed in each request.
+
+```python
+from clip_client import Client
+
+db = {}
+
+
+def my_on_done(resp):
+    for doc in resp.docs:
+        db[doc.id] = doc
+
+
+def my_on_error(resp):
+    with open('error.log', 'a') as f:
+        f.write(resp)
+
+
+def my_on_always(resp):
+    print(f'{len(resp.docs)} docs processed')
+
+
+c = Client('grpc://0.0.0.0:12345')
+c.encode(
+    ['hello', 'world'], on_done=my_on_done, on_error=my_on_error, on_always=my_on_always
+)
+```
+
+```{note}
+If either `on_done` or `on_always` is specified, the default behavior of returning the results is disabled. You need to handle the results yourself.
+```
 
 ### Client parallelism
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,7 +30,7 @@ class Exec2(Executor):
 class ErrorExec(Executor):
     @requests
     def foo(self, docs, **kwargs):
-        1 / 0
+        raise NotImplementedError
 
 
 def test_client_concurrent_requests(port_generator):
@@ -77,7 +77,7 @@ def test_client_large_input(make_torch_flow):
     'inputs',
     [
         [],
-        DocumentArray([]),
+        DocumentArray(),
     ],
 )
 @pytest.mark.parametrize('endpoint', ['encode', 'rank', 'index', 'search'])
@@ -102,7 +102,7 @@ def test_empty_input(make_torch_flow, inputs, endpoint):
     'inputs',
     [
         [],
-        DocumentArray([]),
+        DocumentArray(),
     ],
 )
 @pytest.mark.parametrize('endpoint', ['aencode', 'arank', 'aindex', 'asearch'])


### PR DESCRIPTION
`clip_client` by default collects all the results and returns them to users. In this pr, we enable the user to override this behavior by providing custom callbacks: `on_done`, `on_error`, and `on_always`. The usage of custom callbacks follows that of [Jina client](https://docs.jina.ai/fundamentals/client/client/#callbacks). 

We move all results collection logic to a default `on_done` callback, with or without async.
We also move the code that updates the progress bar to a default `on_always` callback, which wraps the user-defined `on_always` callback.
We do not provide a default `on_error` callback.

This PR also fixes a small bug that unboxes empty input for the rank endpoint to unify the behavior of all endpoints.

- [x] All custom callback in `clip_client`
- [x] Add test cases
- [x] Add documentation
- [x] Bug fix: not unboxing empty input for ranking

