### PR TITLE
fix: install transformers for executor docker images

### DIFF
--- a/.github/README-exec/onnx.readme.md
+++ b/.github/README-exec/onnx.readme.md
@@ -13,24 +13,24 @@ The introduction of the CLIP model [can be found here](https://openai.com/blog/c
 
  `ViT-B-32::openai` is used as the default model. To use specific pretrained models provided by `open_clip`, please use `::` to separate model name and pretrained weight name, e.g. `ViT-B-32::laion2b_e16`. Please also note that **different models give different sizes of output dimensions**.
 
-| Model                                 | PyTorch | Output dimension | 
-|---------------------------------------|---------|------------------|
-| RN50                                  | ✅       | 1024             | 
-| RN101                                 | ✅       | 512              | 
-| RN50x4                                | ✅       | 640              |
-| RN50x16                               | ✅       | 768              |
-| RN50x64                               | ✅       | 1024             |
-| ViT-B-32                              | ✅       | 512              |
-| ViT-B-16                              | ✅       | 512              |
-| ViT-B-16-plus-240                     | ✅       | 640              |
-| ViT-L-14                              | ✅       | 768              |
-| ViT-L-14-336                          | ✅       | 768              |
-| ViT-H-14                              | ✅       | 1024             |
-| ViT-g-14                              | ✅       | 1024             |
-| M-CLIP/XLM_Roberta-Large-Vit-B-32     | ✅       | 512              |
-| M-CLIP/XLM-Roberta-Large-Vit-L-14     | ✅       | 768              |
-| M-CLIP/XLM-Roberta-Large-Vit-B-16Plus | ✅       | 640              |
-| M-CLIP/LABSE-Vit-L-14                 | ✅       | 768              |
+| Model                                 | Onnx | Output dimension | 
+|---------------------------------------|------|------------------|
+| RN50                                  | ✅    | 1024             | 
+| RN101                                 | ✅    | 512              | 
+| RN50x4                                | ✅    | 640              |
+| RN50x16                               | ✅    | 768              |
+| RN50x64                               | ✅    | 1024             |
+| ViT-B-32                              | ✅    | 512              |
+| ViT-B-16                              | ✅    | 512              |
+| ViT-B-16-plus-240                     | ✅    | 640              |
+| ViT-L-14                              | ✅    | 768              |
+| ViT-L-14-336                          | ✅    | 768              |
+| ViT-H-14                              | ✅    | 1024             |
+| ViT-g-14                              | ✅    | 1024             |
+| M-CLIP/XLM_Roberta-Large-Vit-B-32     | ✅    | 512              |
+| M-CLIP/XLM-Roberta-Large-Vit-L-14     | ✅    | 768              |
+| M-CLIP/XLM-Roberta-Large-Vit-B-16Plus | ✅    | 640              |
+| M-CLIP/LABSE-Vit-L-14                 | ✅    | 768              |
 
 ✅ = First class support 
 

--- a/.github/README-exec/onnx.readme.md
+++ b/.github/README-exec/onnx.readme.md
@@ -13,7 +13,7 @@ The introduction of the CLIP model [can be found here](https://openai.com/blog/c
 
  `ViT-B-32::openai` is used as the default model. To use specific pretrained models provided by `open_clip`, please use `::` to separate model name and pretrained weight name, e.g. `ViT-B-32::laion2b_e16`. Please also note that **different models give different sizes of output dimensions**.
 
-| Model                                 | Onnx | Output dimension | 
+| Model                                 | ONNX | Output dimension | 
 |---------------------------------------|------|------------------|
 | RN50                                  | ✅    | 1024             | 
 | RN101                                 | ✅    | 512              | 

--- a/.github/README-exec/onnx.readme.md
+++ b/.github/README-exec/onnx.readme.md
@@ -163,7 +163,7 @@ f = Flow().add(
     uses='jinahub+docker://CLIPTorchEncoder',
 )
 with f:
-    r = f.post(on='/rank', inputs=da)
+    r = f.post(on='/rank', inputs=[d])
     print(r['@m', ['text', 'scores__clip_score__value']])
 ```
 

--- a/.github/README-exec/onnx.readme.md
+++ b/.github/README-exec/onnx.readme.md
@@ -13,18 +13,24 @@ The introduction of the CLIP model [can be found here](https://openai.com/blog/c
 
  `ViT-B-32::openai` is used as the default model. To use specific pretrained models provided by `open_clip`, please use `::` to separate model name and pretrained weight name, e.g. `ViT-B-32::laion2b_e16`. Please also note that **different models give different sizes of output dimensions**.
 
-| Model             | ONNX | Output dimension | 
-|-------------------|------|------------------|
-| RN50              | ✅    | 1024             | 
-| RN101             | ✅    | 512              | 
-| RN50x4            | ✅    | 640              |
-| RN50x16           | ✅    | 768              |
-| RN50x64           | ✅    | 1024             |
-| ViT-B-32          | ✅    | 512              |
-| ViT-B-16          | ✅    | 512              |
-| ViT-B-16-plus-240 | ✅    | 640              |
-| ViT-L-14          | ✅    | 768              |
-| ViT-L-14-336      | ✅    | 768              |
+| Model                                 | PyTorch | Output dimension | 
+|---------------------------------------|---------|------------------|
+| RN50                                  | ✅       | 1024             | 
+| RN101                                 | ✅       | 512              | 
+| RN50x4                                | ✅       | 640              |
+| RN50x16                               | ✅       | 768              |
+| RN50x64                               | ✅       | 1024             |
+| ViT-B-32                              | ✅       | 512              |
+| ViT-B-16                              | ✅       | 512              |
+| ViT-B-16-plus-240                     | ✅       | 640              |
+| ViT-L-14                              | ✅       | 768              |
+| ViT-L-14-336                          | ✅       | 768              |
+| ViT-H-14                              | ✅       | 1024             |
+| ViT-g-14                              | ✅       | 1024             |
+| M-CLIP/XLM_Roberta-Large-Vit-B-32     | ✅       | 512              |
+| M-CLIP/XLM-Roberta-Large-Vit-L-14     | ✅       | 768              |
+| M-CLIP/XLM-Roberta-Large-Vit-B-16Plus | ✅       | 640              |
+| M-CLIP/LABSE-Vit-L-14                 | ✅       | 768              |
 
 ✅ = First class support 
 

--- a/.github/README-exec/onnx.readme.md
+++ b/.github/README-exec/onnx.readme.md
@@ -99,7 +99,7 @@ da = DocumentArray(
 )
 
 f = Flow().add(
-    uses='jinahub+docker://CLIPTorchEncoder',
+    uses='jinahub+docker://CLIPOnnxEncoder',
 )
 with f:
     f.post(on='/', inputs=da)
@@ -160,7 +160,7 @@ Then send the request via `/rank` endpoint:
 
 ```python
 f = Flow().add(
-    uses='jinahub+docker://CLIPTorchEncoder',
+    uses='jinahub+docker://CLIPOnnxEncoder',
 )
 with f:
     r = f.post(on='/rank', inputs=[d])

--- a/.github/README-exec/torch.readme.md
+++ b/.github/README-exec/torch.readme.md
@@ -167,7 +167,7 @@ f = Flow().add(
     uses='jinahub+docker://CLIPTorchEncoder',
 )
 with f:
-    r = f.post(on='/rank', inputs=da)
+    r = f.post(on='/rank', inputs=[d])
     print(r['@m', ['text', 'scores__clip_score__value']])
 ```
 

--- a/.github/README-exec/torch.readme.md
+++ b/.github/README-exec/torch.readme.md
@@ -26,6 +26,8 @@ With advances of ONNX runtime, you can use `CLIPOnnxEncoder` (see [link](https:/
 | ViT-B-16-plus-240                     | ✅       | 640              |
 | ViT-L-14                              | ✅       | 768              |
 | ViT-L-14-336                          | ✅       | 768              |
+| ViT-H-14                              | ✅       | 1024             |
+| ViT-g-14                              | ✅       | 1024             |
 | M-CLIP/XLM_Roberta-Large-Vit-B-32     | ✅       | 512              |
 | M-CLIP/XLM-Roberta-Large-Vit-L-14     | ✅       | 768              |
 | M-CLIP/XLM-Roberta-Large-Vit-B-16Plus | ✅       | 640              |

--- a/Dockerfiles/base.Dockerfile
+++ b/Dockerfiles/base.Dockerfile
@@ -21,8 +21,8 @@ COPY . /cas/
 
 WORKDIR /cas
 
-RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ; fi \
-    && python3 -m pip install --no-cache-dir .
+RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ;  \
+    else python3 -m pip install --no-cache-dir "./[transformers]" ; fi && python3 -m pip install --no-cache-dir .
 
 RUN echo "\
 jtype: CLIPEncoder\n\

--- a/Dockerfiles/base.Dockerfile
+++ b/Dockerfiles/base.Dockerfile
@@ -1,5 +1,5 @@
 # !!! An ARG declared before a FROM is outside of a build stage, so it can’t be used in any instruction after a FROM
-ARG JINA_VERSION=3.7.0
+ARG JINA_VERSION=3.11.0
 
 FROM jinaai/jina:${JINA_VERSION}-py38-standard
 
@@ -14,15 +14,15 @@ LABEL org.opencontainers.image.vendor="Jina AI Limited" \
       org.opencontainers.image.url="clip-as-service" \
       org.opencontainers.image.documentation="https://clip-as-service.jina.ai/"
 
-RUN pip3 install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install --no-cache-dir torch torchvision torchaudio transformers --extra-index-url https://download.pytorch.org/whl/cpu
 
 # copy will almost always invalid the cache
 COPY . /cas/
 
 WORKDIR /cas
 
-RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ;  \
-    else python3 -m pip install --no-cache-dir "./[transformers]" ; fi && python3 -m pip install --no-cache-dir .
+RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ; fi \
+    && python3 -m pip install --no-cache-dir .
 
 RUN echo "\
 jtype: CLIPEncoder\n\

--- a/Dockerfiles/cuda.Dockerfile
+++ b/Dockerfiles/cuda.Dockerfile
@@ -3,7 +3,7 @@ ARG CUDA_VERSION=11.4.2
 FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG JINA_VERSION=3.7.0
+ARG JINA_VERSION=3.11.0
 ARG BACKEND_TAG=torch
 
 # constant, wont invalidate cache
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-setuptools python3-wheel python3-pip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*;
 
-RUN python3 -m pip install --default-timeout=1000 --no-cache-dir torch torchvision torchaudio nvidia-pyindex --extra-index-url https://download.pytorch.org/whl/cu113
+RUN python3 -m pip install --default-timeout=1000 --no-cache-dir torch torchvision torchaudio nvidia-pyindex transformers --extra-index-url https://download.pytorch.org/whl/cu113
 RUN python3 -m pip install --default-timeout=1000 --no-cache-dir "jina[standard]==${JINA_VERSION}"
 
 # copy will almost always invalid the cache
@@ -27,8 +27,8 @@ COPY . /cas/
 
 WORKDIR /cas
 
-RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ;  \
-    else python3 -m pip install --no-cache-dir "./[transformers]" ; fi && python3 -m pip install --no-cache-dir .
+RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ; fi \
+    && python3 -m pip install --no-cache-dir .
 
 RUN echo "\
 jtype: CLIPEncoder\n\

--- a/Dockerfiles/cuda.Dockerfile
+++ b/Dockerfiles/cuda.Dockerfile
@@ -27,8 +27,8 @@ COPY . /cas/
 
 WORKDIR /cas
 
-RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ; fi \
-    && python3 -m pip install --no-cache-dir .
+RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ;  \
+    else python3 -m pip install --no-cache-dir "./[transformers]" ; fi && python3 -m pip install --no-cache-dir .
 
 RUN echo "\
 jtype: CLIPEncoder\n\


### PR DESCRIPTION
This pr installs the missing `transformers` package for torch & onnx executor docker images in hubble so that users can use M-CLIP models.

It also updates the hubble executor readme. 