### PR TITLE
fix: increase timeout ready for executor docker images

### DIFF
--- a/Dockerfiles/base.Dockerfile
+++ b/Dockerfiles/base.Dockerfile
@@ -21,8 +21,8 @@ COPY . /cas/
 
 WORKDIR /cas
 
-RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ; fi \
-    && python3 -m pip install --no-cache-dir .
+RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ;  \
+    else python3 -m pip install --no-cache-dir "./[transformers]" ; fi && python3 -m pip install --no-cache-dir .
 
 RUN echo "\
 jtype: CLIPEncoder\n\

--- a/Dockerfiles/base.Dockerfile
+++ b/Dockerfiles/base.Dockerfile
@@ -21,8 +21,8 @@ COPY . /cas/
 
 WORKDIR /cas
 
-RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ;  \
-    else python3 -m pip install --no-cache-dir "./[transformers]" ; fi && python3 -m pip install --no-cache-dir .
+RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ; fi \
+    && python3 -m pip install --no-cache-dir .
 
 RUN echo "\
 jtype: CLIPEncoder\n\

--- a/Dockerfiles/base.Dockerfile
+++ b/Dockerfiles/base.Dockerfile
@@ -32,4 +32,4 @@ metas:\n\
 " > /tmp/config.yml
 
 
-ENTRYPOINT ["jina", "executor", "--uses", "/tmp/config.yml"]
+ENTRYPOINT ["jina", "executor", "--uses", "/tmp/config.yml", "--timeout-ready", "3000000"]

--- a/Dockerfiles/cuda.Dockerfile
+++ b/Dockerfiles/cuda.Dockerfile
@@ -27,8 +27,8 @@ COPY . /cas/
 
 WORKDIR /cas
 
-RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ;  \
-    else python3 -m pip install --no-cache-dir "./[transformers]" ; fi && python3 -m pip install --no-cache-dir .
+RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ; fi \
+    && python3 -m pip install --no-cache-dir .
 
 RUN echo "\
 jtype: CLIPEncoder\n\

--- a/Dockerfiles/cuda.Dockerfile
+++ b/Dockerfiles/cuda.Dockerfile
@@ -27,8 +27,8 @@ COPY . /cas/
 
 WORKDIR /cas
 
-RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ; fi \
-    && python3 -m pip install --no-cache-dir .
+RUN if [ "${BACKEND_TAG}" != "torch" ]; then python3 -m pip install --no-cache-dir "./[${BACKEND_TAG}]" ;  \
+    else python3 -m pip install --no-cache-dir "./[transformers]" ; fi && python3 -m pip install --no-cache-dir .
 
 RUN echo "\
 jtype: CLIPEncoder\n\

--- a/Dockerfiles/cuda.Dockerfile
+++ b/Dockerfiles/cuda.Dockerfile
@@ -37,7 +37,7 @@ metas:\n\
     - clip_server.executors.clip_$BACKEND_TAG\n\
 " > /tmp/config.yml
 
-ENTRYPOINT ["jina", "executor", "--uses", "/tmp/config.yml"]
+ENTRYPOINT ["jina", "executor", "--uses", "/tmp/config.yml", "--timeout-ready", "3000000"]
 
 
 


### PR DESCRIPTION
ViT-g/h and M-CLIP models usually take longer to download and have a high chance to timeout at the starting stage. This pr increases `timeout_ready` to 3000000ms