### PR TITLE
feat: add custom tracing spans with jina>=3.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,217 +6,32 @@
 <br>
 <br>
 <br>
-<b>Embed images and sentences into fixed-length vectors with CLIP</b>
+<b>Embedding image and sentence into fixed-length vectors via CLIP</b>
 </p>
 
 <p align=center>
-<a href="https://pypi.org/project/clip_server/"><img alt="PyPI" src="https://img.shields.io/pypi/v/clip_server?label=Release&style=flat-square"></a>
-<a href="https://slack.jina.ai"><img src="https://img.shields.io/badge/Slack-3.1k-blueviolet?logo=slack&amp;logoColor=white&style=flat-square"></a>
-<a href="https://codecov.io/gh/jina-ai/clip-as-service"><img alt="Codecov branch" src="https://img.shields.io/codecov/c/github/jina-ai/clip-as-service/main?logo=Codecov&logoColor=white&style=flat-square"></a>
-<a href="https://colab.research.google.com/github/jina-ai/clip-as-service/blob/main/docs/hosting/cas-on-colab.ipynb"><img src="https://img.shields.io/badge/Host-on%20Google%20Colab%20(GPU/TPU)-brightgreen?style=flat-square&logo=googlecolab&&logoColor=white" alt="Host on Google Colab with GPU/TPU support"></a>
+<a href="https://pypi.org/project/clip_server/"><img src="https://github.com/jina-ai/jina/blob/master/.github/badges/python-badge.svg?raw=true" alt="Python 3.7 3.8 3.9 3.10" title="CLIP-as-service supports Python 3.7 and above"></a>
+<a href="https://pypi.org/project/clip_server/"><img src="https://img.shields.io/pypi/v/clip_server?color=%23099cec&amp;label=PyPI&amp;logo=pypi&amp;logoColor=white" alt="PyPI"></a>
+<a href="https://slack.jina.ai"><img src="https://img.shields.io/badge/Slack-2.7k%2B-blueviolet?logo=slack&amp;logoColor=white"></a>
 </p>
 
 <!-- start elevator-pitch -->
 
-CLIP-as-service is a low-latency high-scalability service for embedding images and text. It can be easily integrated as a microservice into neural search solutions.
+CLIP-as-service is a low-latency high-scalability embedding service for images and texts. It can be easily integrated as a microservice into neural search solutions.
 
-⚡ **Fast**: Serve CLIP models with TensorRT, ONNX runtime and PyTorch w/o JIT with 800QPS<sup>[*]</sup>. Non-blocking duplex streaming on requests and responses, designed for large data and long-running tasks. 
+⚡ **Fast**: Serve CLIP models with ONNX runtime and PyTorch JIT with 800QPS<sup>[*]</sup>. Non-blocking duplex streaming on requests and responses, designed for large data and long-running tasks. 
 
 🫐 **Elastic**: Horizontally scale up and down multiple CLIP models on single GPU, with automatic load balancing.
 
 🐥 **Easy-to-use**: No learning curve, minimalist design on client and server. Intuitive and consistent API for image and sentence embedding. 
 
-👒 **Modern**: Async client support. Easily switch between gRPC, HTTP, WebSocket protocols with TLS and compression.
+👒 **Modern**: Async client support. Easily switch between gRPC, HTTP, Websocket protocols with TLS and compressions.
 
-🍱 **Integration**: Smooth integration with neural search ecosystem including [Jina](https://github.com/jina-ai/jina) and [DocArray](https://github.com/jina-ai/docarray). Build cross-modal and multi-modal solutions in no time. 
+🍱 **Integration**: Smoothly integrated with neural search ecosystem including [Jina](https://github.com/jina-ai/jina) and [DocArray](https://github.com/jina-ai/docarray). Build cross-modal and multi-modal solution in no time. 
 
 <sup>[*] with default config (single replica, PyTorch no JIT) on GeForce RTX 3090. </sup>
 
 <!-- end elevator-pitch -->
-
-## Try it!
-
-An always-online server `api.clip.jina.ai` loaded with `ViT-L-14-336::openai` is there for you to play & test.
-Before you start, make sure you have obtained an access token from our [console website](https://console.clip.jina.ai/get_started), 
-or via CLI as described in [this guide](https://docs.jina.ai/jina-ai-cloud/login/#create-a-new-pat).
-
-```bash 
-jina auth token create <name of PAT> -e <expiration days>
-```
-
-Then, you need to configure the access token in the parameter `credential` of the client in python or set it in the HTTP request header `Authorization` as `<your access token>`.
-
-⚠️ Our demo server `demo-cas.jina.ai` is sunset and no longer available after **15th of Sept 2022**. 
-
-
-### Text & image embedding
-
-<table>
-<tr>
-<td> via HTTPS 🔐 </td>
-<td> via gRPC 🔐⚡⚡ </td>
-</tr>
-<tr>
-<td>
-
-```bash
-curl \
--X POST https://api.clip.jina.ai:8443/post \
--H 'Content-Type: application/json' \
--H 'Authorization: <your access token>' \
--d '{"data":[{"text": "First do it"}, 
-    {"text": "then do it right"}, 
-    {"text": "then do it better"}, 
-    {"uri": "https://picsum.photos/200"}], 
-    "execEndpoint":"/"}'
-```
-
-</td>
-<td>
-
-```python
-# pip install clip-client
-from clip_client import Client
-
-c = Client(
-    'grpcs://api.clip.jina.ai:2096', credential={'Authorization': '<your access token>'}
-)
-
-r = c.encode(
-    [
-        'First do it',
-        'then do it right',
-        'then do it better',
-        'https://picsum.photos/200',
-    ]
-)
-print(r)
-```
-</td>
-</tr>
-</table>
-
-### Visual reasoning
-
-There are four basic visual reasoning skills: object recognition, object counting, color recognition, and spatial relation understanding. Let's try some:
-
-> You need to install [`jq` (a JSON processor)](https://stedolan.github.io/jq/) to prettify the results.
-
-<table>
-<tr>
-<td> Image </td>
-<td> via HTTPS 🔐 </td>
-</tr>
-<tr>
-<td>
-<img src="https://picsum.photos/id/1/300/300">
-</td>
-<td>
-
-```bash
-curl \
--X POST https://api.clip.jina.ai:8443/post \
--H 'Content-Type: application/json' \
--H 'Authorization: <your access token>' \
--d '{"data":[{"uri": "https://picsum.photos/id/1/300/300",
-"matches": [{"text": "there is a woman in the photo"},
-            {"text": "there is a man in the photo"}]}],
-            "execEndpoint":"/rank"}' \
-| jq ".data[].matches[] | (.text, .scores.clip_score.value)"
-```
-
-gives:
-
-```
-"there is a woman in the photo"
-0.626907229423523
-"there is a man in the photo"
-0.37309277057647705
-```
-
-</td>
-</tr>
-<tr>
-<td>
-<img src="https://picsum.photos/id/133/300/300">
-</td>
-<td>
-
-```bash
-curl \
--X POST https://api.clip.jina.ai:8443/post \
--H 'Content-Type: application/json' \
--H 'Authorization: <your access token>' \
--d '{"data":[{"uri": "https://picsum.photos/id/133/300/300",
-"matches": [
-{"text": "the blue car is on the left, the red car is on the right"},
-{"text": "the blue car is on the right, the red car is on the left"},
-{"text": "the blue car is on top of the red car"},
-{"text": "the blue car is below the red car"}]}],
-"execEndpoint":"/rank"}' \
-| jq ".data[].matches[] | (.text, .scores.clip_score.value)"
-```
-
-gives:
-```
-"the blue car is on the left, the red car is on the right"
-0.5232442617416382
-"the blue car is on the right, the red car is on the left"
-0.32878655195236206
-"the blue car is below the red car"
-0.11064132302999496
-"the blue car is on top of the red car"
-0.03732786327600479
-```
-
-</td>
-</tr>
-
-
-<tr>
-<td>
-<img src="https://picsum.photos/id/102/300/300">
-</td>
-<td>
-
-```bash
-curl \
--X POST https://api.clip.jina.ai:8443/post \
--H 'Content-Type: application/json' \
--H 'Authorization: <your access token>' \
--d '{"data":[{"uri": "https://picsum.photos/id/102/300/300",
-"matches": [{"text": "this is a photo of one berry"},
-            {"text": "this is a photo of two berries"},
-            {"text": "this is a photo of three berries"},
-            {"text": "this is a photo of four berries"},
-            {"text": "this is a photo of five berries"},
-            {"text": "this is a photo of six berries"}]}],
-            "execEndpoint":"/rank"}' \
-| jq ".data[].matches[] | (.text, .scores.clip_score.value)"
-```
-
-gives:
-```
-"this is a photo of three berries"
-0.48507222533226013
-"this is a photo of four berries"
-0.2377079576253891
-"this is a photo of one berry"
-0.11304923892021179
-"this is a photo of five berries"
-0.0731358453631401
-"this is a photo of two berries"
-0.05045759305357933
-"this is a photo of six berries"
-0.04057715833187103
-```
-
-</td>
-</tr>
-
-
-</table>
-
 
 ## [Documentation](https://clip-as-service.jina.ai)
 
@@ -226,38 +41,15 @@ CLIP-as-service consists of two Python packages `clip-server` and `clip-client` 
 
 ### Install server
 
-<table>
-<tr>
-<td> Pytorch Runtime ⚡ </td>
-<td> ONNX Runtime ⚡⚡</td>
-<td> TensorRT Runtime ⚡⚡⚡ </td>
-</tr>
-<tr>
-<td>
-
 ```bash
 pip install clip-server
 ```
 
-</td>
-<td>
+To run CLIP model via ONNX (default is via PyTorch):
 
 ```bash
 pip install "clip-server[onnx]"
 ```
-
-</td>
-<td>
-
-```bash
-pip install nvidia-pyindex 
-pip install "clip-server[tensorrt]"
-```
-</td>
-</tr>
-</table>
-
-You can also [host the server on Google Colab](https://clip-as-service.jina.ai/hosting/colab/), leveraging its free GPU/TPU.
 
 ### Install client
 
@@ -316,7 +108,7 @@ c.profile()
 </table>
 
 
-You can change `0.0.0.0` to the intranet or public IP address to test the connectivity over private and public network. 
+You can change `0.0.0.0` to the intranet or public IP address to test the connectivity over private and public network. If you encounter some errors, please find the solution here.  
 
 
 ## Get Started
@@ -328,7 +120,7 @@ You can change `0.0.0.0` to the intranet or public IP address to test the connec
    ```python
     from clip_client import Client
    
-    c = Client('grpc://0.0.0.0:51000')
+    c = Client('grpc://87.191.159.105:51000')
     ```
 3. To get sentence embedding:
     ```python    
@@ -339,21 +131,21 @@ You can change `0.0.0.0` to the intranet or public IP address to test the connec
 4. To get image embedding:
     ```python    
     r = c.encode(['apple.png',  # local image 
-                  'https://clip-as-service.jina.ai/_static/favicon.png',  # remote image
+                  'https://docarray.jina.ai/_static/favicon.png',  # remote image
                   'data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7'])  # in image URI
     
     print(r.shape)  # [3, 512]
     ```
 
-More comprehensive server and client user guides can be found in the [docs](https://clip-as-service.jina.ai/).
+More comprehensive server & client configs can be found in the docs.
 
-### Text-to-image cross-modal search in 10 lines
+### Text-to-image cross-modal search in 10 Lines
 
-Let's build a text-to-image search using CLIP-as-service. Namely, a user can input a sentence and the program returns matching images. We'll use the [Totally Looks Like](https://sites.google.com/view/totally-looks-like-dataset) dataset and [DocArray](https://github.com/jina-ai/docarray) package. Note that DocArray is included within `clip-client` as an upstream dependency, so you don't need to install it separately.
+Let's build a text-to-image search using CLIP-as-service. Namely, user input a sentence and the program returns the matched images. We will use [Totally Looks Like](https://sites.google.com/view/totally-looks-like-dataset) dataset and [DocArray](https://github.com/jina-ai/docarray) package. Note that DocArray is included within `clip-client` as an upstream dependency, so you don't need to install it separately.
 
 #### Load images
 
-First we load images. You can simply pull them from Jina Cloud:
+First we load images. You can simply pull it from Jina Cloud:
 
 ```python
 from docarray import DocumentArray
@@ -364,7 +156,7 @@ da = DocumentArray.pull('ttl-original', show_progress=True, local_cache=True)
 <details>
 <summary>or download TTL dataset, unzip, load manually</summary>
 
-Alternatively, you can go to [Totally Looks Like](https://sites.google.com/view/totally-looks-like-dataset) official website, unzip and load images:
+Alternatively, you can go to [Totally Looks Like](https://sites.google.com/view/totally-looks-like-dataset) official website, unzip and load images as follows:
 
 ```python
 from docarray import DocumentArray
@@ -374,7 +166,7 @@ da = DocumentArray.from_files(['left/*.jpg', 'right/*.jpg'])
 
 </details>
 
-The dataset contains 12,032 images, so it may take a while to pull. Once done, you can visualize it and get the first taste of those images:
+The dataset contains 12,032 images, hence it may take half minute to pull. Once done, you can visualize it and get the first taste of those images.
 
 ```python
 da.plot_image_sprites()
@@ -386,24 +178,23 @@ da.plot_image_sprites()
 
 #### Encode images
 
-Start the server with `python -m clip_server`. Let's say it's at `0.0.0.0:51000` with `GRPC` protocol (you will get this information after running the server).
+Start the server with `python -m clip_server`. Say it is at `87.191.159.105:51000` with `GRPC` protocol (you will get this information after running the server).
 
 Create a Python client script:
-
 ```python
 from clip_client import Client
 
-c = Client(server='grpc://0.0.0.0:51000')
+c = Client(server='grpc://87.191.159.105:51000')
 
 da = c.encode(da, show_progress=True)
 ```
 
-Depending on your GPU and client-server network, it may take a while to embed 12K images. In my case, it took about two minutes.
+Depending on your GPU and client-server network, it could take a while to embed 12K images. In my case, it takes ~2 minute.
 
 <details>
 <summary>Download the pre-encoded dataset</summary>
 
-If you're impatient or don't have a GPU, waiting can be Hell. In this case, you can simply pull our pre-encoded image dataset:
+For people who are impatient or lack of GPU, waiting can be a hell. In this case, you can simply pull our pre-encoded image dataset.
 
 ```python
 from docarray import DocumentArray
@@ -415,18 +206,18 @@ da = DocumentArray.pull('ttl-embedding', show_progress=True, local_cache=True)
 
 #### Search via sentence 
 
-Let's build a simple prompt to allow a user to type sentence:
+Let's build a simple prompt to allow user to type sentence:
 
 ```python
 while True:
     vec = c.encode([input('sentence> ')])
     r = da.find(query=vec, limit=9)
-    r[0].plot_image_sprites()
+    r.plot_image_sprites()
 ```
 
 #### Showcase
 
-Now you can input arbitrary English sentences and view the top-9 matching images. Search is fast and instinctive. Let's have some fun:
+Now you can input arbitrary English sentences and view the top-9 matched images. Search is fast and instinct. Let's have some fun:
 
 <table>
 <tr>
@@ -535,12 +326,12 @@ da.summary()
 
 #### Encode sentences
 
-Now encode these 6,403 sentences, it may take 10 seconds or less depending on your GPU and network: 
+Now encode these 6403 sentences, it may take 10s or less depending on your GPU and network: 
 
 ```python
 from clip_client import Client
 
-c = Client('grpc://0.0.0.0:51000')
+c = Client('grpc://87.191.159.105:51000')
 
 r = c.encode(da, show_progress=True)
 ```
@@ -548,7 +339,7 @@ r = c.encode(da, show_progress=True)
 <details>
 <summary>Download the pre-encoded dataset</summary>
 
-Again, for people who are impatient or don't have a GPU, we have prepared a pre-encoded text dataset:
+Again, for people who are impatient or lack of GPU, we have prepared a pre-encoded text dataset.
 
 ```python
 from docarray import DocumentArray
@@ -560,7 +351,7 @@ da = DocumentArray.pull('ttl-textual', show_progress=True, local_cache=True)
 
 #### Search via image
 
-Let's load our previously stored image embedding, randomly sample 10 image Documents, then find top-1 nearest neighbour of each.
+Let's load our previously stored image embedding; randomly sample image Document from it, then find top-1 nearest neighbour of each.
 
 ```python
 from docarray import DocumentArray
@@ -573,7 +364,7 @@ for d in img_da.sample(10):
 
 #### Showcase
 
-Fun time! Note, unlike the previous example, here the input is an image and the sentence is the output. All sentences come from the book "Pride and Prejudice". 
+Fun time! Note, unlike the previous example, here the input is an image, the sentence is the output. All sentences come from the book "Pride and Prejudice". 
 
 <table>
 <tr>
@@ -672,83 +463,14 @@ Fun time! Note, unlike the previous example, here the input is an image and the 
 </table>
 
 
-
-### Rank image-text matches via CLIP model
-
-From `0.3.0` CLIP-as-service adds a new `/rank` endpoint that re-ranks cross-modal matches according to their joint likelihood in CLIP model. For example, given an image Document with some predefined sentence matches as below:
-
-```python
-from clip_client import Client
-from docarray import Document
-
-c = Client(server='grpc://0.0.0.0:51000')
-r = c.rank(
-    [
-        Document(
-            uri='.github/README-img/rerank.png',
-            matches=[
-                Document(text=f'a photo of a {p}')
-                for p in (
-                    'control room',
-                    'lecture room',
-                    'conference room',
-                    'podium indoor',
-                    'television studio',
-                )
-            ],
-        )
-    ]
-)
-
-print(r['@m', ['text', 'scores__clip_score__value']])
-```
-
-```text
-[['a photo of a television studio', 'a photo of a conference room', 'a photo of a lecture room', 'a photo of a control room', 'a photo of a podium indoor'], 
-[0.9920725226402283, 0.006038925610482693, 0.0009973491542041302, 0.00078492151806131, 0.00010626466246321797]]
-```
-
-One can see now `a photo of a television studio` is ranked to the top with `clip_score` score at `0.992`. In practice, one can use this endpoint to re-rank the matching result from another search system, for improving the cross-modal search quality.
-
-<table>
-<tr>
-<td>
-<img src="https://github.com/jina-ai/clip-as-service/blob/main/.github/README-img/rerank.png?raw=true" alt="Rerank endpoint image input" height="150px">
-</td>
-<td>
-<img src="https://github.com/jina-ai/clip-as-service/blob/main/.github/README-img/rerank-chart.svg?raw=true" alt="Rerank endpoint output">
-</td>
-</tr>
-</table>
-
-### Rank text-image matches via CLIP model
-
-In the [DALL·E Flow](https://github.com/jina-ai/dalle-flow) project, CLIP is called for ranking the generated results from DALL·E. [It has an Executor wrapped on top of `clip-client`](https://github.com/jina-ai/dalle-flow/blob/main/executors/rerank/executor.py), which calls `.arank()` - the async version of `.rank()`:
-
-```python
-from clip_client import Client
-from jina import Executor, requests, DocumentArray
-
-
-class ReRank(Executor):
-    def __init__(self, clip_server: str, **kwargs):
-        super().__init__(**kwargs)
-        self._client = Client(server=clip_server)
-
-    @requests(on='/')
-    async def rerank(self, docs: DocumentArray, **kwargs):
-        return await self._client.arank(docs)
-```
-
-<p align="center">
-<img src="https://github.com/jina-ai/clip-as-service/blob/main/.github/README-img/client-dalle.png?raw=true" alt="CLIP-as-service used in DALLE Flow" width="300px">
-</p>
-
 Intrigued? That's only scratching the surface of what CLIP-as-service is capable of. [Read our docs to learn more](https://clip-as-service.jina.ai).
+
 
 <!-- start support-pitch -->
 ## Support
 
+- Use [Discussions](https://github.com/jina-ai/clip-as-service/discussions) to talk about your use cases, questions, and
+  support queries.
 - Join our [Slack community](https://slack.jina.ai) and chat with other community members about ideas.
 - Join our [Engineering All Hands](https://youtube.com/playlist?list=PL3UBBWOUVhFYRUa_gpYYKBqEAkO4sxmne) meet-up to discuss your use case and learn Jina's new features.
     - **When?** The second Tuesday of every month

--- a/README.md
+++ b/README.md
@@ -6,32 +6,217 @@
 <br>
 <br>
 <br>
-<b>Embedding image and sentence into fixed-length vectors via CLIP</b>
+<b>Embed images and sentences into fixed-length vectors with CLIP</b>
 </p>
 
 <p align=center>
-<a href="https://pypi.org/project/clip_server/"><img src="https://github.com/jina-ai/jina/blob/master/.github/badges/python-badge.svg?raw=true" alt="Python 3.7 3.8 3.9 3.10" title="CLIP-as-service supports Python 3.7 and above"></a>
-<a href="https://pypi.org/project/clip_server/"><img src="https://img.shields.io/pypi/v/clip_server?color=%23099cec&amp;label=PyPI&amp;logo=pypi&amp;logoColor=white" alt="PyPI"></a>
-<a href="https://slack.jina.ai"><img src="https://img.shields.io/badge/Slack-2.7k%2B-blueviolet?logo=slack&amp;logoColor=white"></a>
+<a href="https://pypi.org/project/clip_server/"><img alt="PyPI" src="https://img.shields.io/pypi/v/clip_server?label=Release&style=flat-square"></a>
+<a href="https://slack.jina.ai"><img src="https://img.shields.io/badge/Slack-3.1k-blueviolet?logo=slack&amp;logoColor=white&style=flat-square"></a>
+<a href="https://codecov.io/gh/jina-ai/clip-as-service"><img alt="Codecov branch" src="https://img.shields.io/codecov/c/github/jina-ai/clip-as-service/main?logo=Codecov&logoColor=white&style=flat-square"></a>
+<a href="https://colab.research.google.com/github/jina-ai/clip-as-service/blob/main/docs/hosting/cas-on-colab.ipynb"><img src="https://img.shields.io/badge/Host-on%20Google%20Colab%20(GPU/TPU)-brightgreen?style=flat-square&logo=googlecolab&&logoColor=white" alt="Host on Google Colab with GPU/TPU support"></a>
 </p>
 
 <!-- start elevator-pitch -->
 
-CLIP-as-service is a low-latency high-scalability embedding service for images and texts. It can be easily integrated as a microservice into neural search solutions.
+CLIP-as-service is a low-latency high-scalability service for embedding images and text. It can be easily integrated as a microservice into neural search solutions.
 
-⚡ **Fast**: Serve CLIP models with ONNX runtime and PyTorch JIT with 800QPS<sup>[*]</sup>. Non-blocking duplex streaming on requests and responses, designed for large data and long-running tasks. 
+⚡ **Fast**: Serve CLIP models with TensorRT, ONNX runtime and PyTorch w/o JIT with 800QPS<sup>[*]</sup>. Non-blocking duplex streaming on requests and responses, designed for large data and long-running tasks. 
 
 🫐 **Elastic**: Horizontally scale up and down multiple CLIP models on single GPU, with automatic load balancing.
 
 🐥 **Easy-to-use**: No learning curve, minimalist design on client and server. Intuitive and consistent API for image and sentence embedding. 
 
-👒 **Modern**: Async client support. Easily switch between gRPC, HTTP, Websocket protocols with TLS and compressions.
+👒 **Modern**: Async client support. Easily switch between gRPC, HTTP, WebSocket protocols with TLS and compression.
 
-🍱 **Integration**: Smoothly integrated with neural search ecosystem including [Jina](https://github.com/jina-ai/jina) and [DocArray](https://github.com/jina-ai/docarray). Build cross-modal and multi-modal solution in no time. 
+🍱 **Integration**: Smooth integration with neural search ecosystem including [Jina](https://github.com/jina-ai/jina) and [DocArray](https://github.com/jina-ai/docarray). Build cross-modal and multi-modal solutions in no time. 
 
 <sup>[*] with default config (single replica, PyTorch no JIT) on GeForce RTX 3090. </sup>
 
 <!-- end elevator-pitch -->
+
+## Try it!
+
+An always-online server `api.clip.jina.ai` loaded with `ViT-L-14-336::openai` is there for you to play & test.
+Before you start, make sure you have obtained an access token from our [console website](https://console.clip.jina.ai/get_started), 
+or via CLI as described in [this guide](https://docs.jina.ai/jina-ai-cloud/login/#create-a-new-pat).
+
+```bash 
+jina auth token create <name of PAT> -e <expiration days>
+```
+
+Then, you need to configure the access token in the parameter `credential` of the client in python or set it in the HTTP request header `Authorization` as `<your access token>`.
+
+⚠️ Our demo server `demo-cas.jina.ai` is sunset and no longer available after **15th of Sept 2022**. 
+
+
+### Text & image embedding
+
+<table>
+<tr>
+<td> via HTTPS 🔐 </td>
+<td> via gRPC 🔐⚡⚡ </td>
+</tr>
+<tr>
+<td>
+
+```bash
+curl \
+-X POST https://api.clip.jina.ai:8443/post \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <your access token>' \
+-d '{"data":[{"text": "First do it"}, 
+    {"text": "then do it right"}, 
+    {"text": "then do it better"}, 
+    {"uri": "https://picsum.photos/200"}], 
+    "execEndpoint":"/"}'
+```
+
+</td>
+<td>
+
+```python
+# pip install clip-client
+from clip_client import Client
+
+c = Client(
+    'grpcs://api.clip.jina.ai:2096', credential={'Authorization': '<your access token>'}
+)
+
+r = c.encode(
+    [
+        'First do it',
+        'then do it right',
+        'then do it better',
+        'https://picsum.photos/200',
+    ]
+)
+print(r)
+```
+</td>
+</tr>
+</table>
+
+### Visual reasoning
+
+There are four basic visual reasoning skills: object recognition, object counting, color recognition, and spatial relation understanding. Let's try some:
+
+> You need to install [`jq` (a JSON processor)](https://stedolan.github.io/jq/) to prettify the results.
+
+<table>
+<tr>
+<td> Image </td>
+<td> via HTTPS 🔐 </td>
+</tr>
+<tr>
+<td>
+<img src="https://picsum.photos/id/1/300/300">
+</td>
+<td>
+
+```bash
+curl \
+-X POST https://api.clip.jina.ai:8443/post \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <your access token>' \
+-d '{"data":[{"uri": "https://picsum.photos/id/1/300/300",
+"matches": [{"text": "there is a woman in the photo"},
+            {"text": "there is a man in the photo"}]}],
+            "execEndpoint":"/rank"}' \
+| jq ".data[].matches[] | (.text, .scores.clip_score.value)"
+```
+
+gives:
+
+```
+"there is a woman in the photo"
+0.626907229423523
+"there is a man in the photo"
+0.37309277057647705
+```
+
+</td>
+</tr>
+<tr>
+<td>
+<img src="https://picsum.photos/id/133/300/300">
+</td>
+<td>
+
+```bash
+curl \
+-X POST https://api.clip.jina.ai:8443/post \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <your access token>' \
+-d '{"data":[{"uri": "https://picsum.photos/id/133/300/300",
+"matches": [
+{"text": "the blue car is on the left, the red car is on the right"},
+{"text": "the blue car is on the right, the red car is on the left"},
+{"text": "the blue car is on top of the red car"},
+{"text": "the blue car is below the red car"}]}],
+"execEndpoint":"/rank"}' \
+| jq ".data[].matches[] | (.text, .scores.clip_score.value)"
+```
+
+gives:
+```
+"the blue car is on the left, the red car is on the right"
+0.5232442617416382
+"the blue car is on the right, the red car is on the left"
+0.32878655195236206
+"the blue car is below the red car"
+0.11064132302999496
+"the blue car is on top of the red car"
+0.03732786327600479
+```
+
+</td>
+</tr>
+
+
+<tr>
+<td>
+<img src="https://picsum.photos/id/102/300/300">
+</td>
+<td>
+
+```bash
+curl \
+-X POST https://api.clip.jina.ai:8443/post \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <your access token>' \
+-d '{"data":[{"uri": "https://picsum.photos/id/102/300/300",
+"matches": [{"text": "this is a photo of one berry"},
+            {"text": "this is a photo of two berries"},
+            {"text": "this is a photo of three berries"},
+            {"text": "this is a photo of four berries"},
+            {"text": "this is a photo of five berries"},
+            {"text": "this is a photo of six berries"}]}],
+            "execEndpoint":"/rank"}' \
+| jq ".data[].matches[] | (.text, .scores.clip_score.value)"
+```
+
+gives:
+```
+"this is a photo of three berries"
+0.48507222533226013
+"this is a photo of four berries"
+0.2377079576253891
+"this is a photo of one berry"
+0.11304923892021179
+"this is a photo of five berries"
+0.0731358453631401
+"this is a photo of two berries"
+0.05045759305357933
+"this is a photo of six berries"
+0.04057715833187103
+```
+
+</td>
+</tr>
+
+
+</table>
+
 
 ## [Documentation](https://clip-as-service.jina.ai)
 
@@ -41,15 +226,38 @@ CLIP-as-service consists of two Python packages `clip-server` and `clip-client` 
 
 ### Install server
 
+<table>
+<tr>
+<td> Pytorch Runtime ⚡ </td>
+<td> ONNX Runtime ⚡⚡</td>
+<td> TensorRT Runtime ⚡⚡⚡ </td>
+</tr>
+<tr>
+<td>
+
 ```bash
 pip install clip-server
 ```
 
-To run CLIP model via ONNX (default is via PyTorch):
+</td>
+<td>
 
 ```bash
 pip install "clip-server[onnx]"
 ```
+
+</td>
+<td>
+
+```bash
+pip install nvidia-pyindex 
+pip install "clip-server[tensorrt]"
+```
+</td>
+</tr>
+</table>
+
+You can also [host the server on Google Colab](https://clip-as-service.jina.ai/hosting/colab/), leveraging its free GPU/TPU.
 
 ### Install client
 
@@ -108,7 +316,7 @@ c.profile()
 </table>
 
 
-You can change `0.0.0.0` to the intranet or public IP address to test the connectivity over private and public network. If you encounter some errors, please find the solution here.  
+You can change `0.0.0.0` to the intranet or public IP address to test the connectivity over private and public network. 
 
 
 ## Get Started
@@ -120,7 +328,7 @@ You can change `0.0.0.0` to the intranet or public IP address to test the connec
    ```python
     from clip_client import Client
    
-    c = Client('grpc://87.191.159.105:51000')
+    c = Client('grpc://0.0.0.0:51000')
     ```
 3. To get sentence embedding:
     ```python    
@@ -131,21 +339,21 @@ You can change `0.0.0.0` to the intranet or public IP address to test the connec
 4. To get image embedding:
     ```python    
     r = c.encode(['apple.png',  # local image 
-                  'https://docarray.jina.ai/_static/favicon.png',  # remote image
+                  'https://clip-as-service.jina.ai/_static/favicon.png',  # remote image
                   'data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7'])  # in image URI
     
     print(r.shape)  # [3, 512]
     ```
 
-More comprehensive server & client configs can be found in the docs.
+More comprehensive server and client user guides can be found in the [docs](https://clip-as-service.jina.ai/).
 
-### Text-to-image cross-modal search in 10 Lines
+### Text-to-image cross-modal search in 10 lines
 
-Let's build a text-to-image search using CLIP-as-service. Namely, user input a sentence and the program returns the matched images. We will use [Totally Looks Like](https://sites.google.com/view/totally-looks-like-dataset) dataset and [DocArray](https://github.com/jina-ai/docarray) package. Note that DocArray is included within `clip-client` as an upstream dependency, so you don't need to install it separately.
+Let's build a text-to-image search using CLIP-as-service. Namely, a user can input a sentence and the program returns matching images. We'll use the [Totally Looks Like](https://sites.google.com/view/totally-looks-like-dataset) dataset and [DocArray](https://github.com/jina-ai/docarray) package. Note that DocArray is included within `clip-client` as an upstream dependency, so you don't need to install it separately.
 
 #### Load images
 
-First we load images. You can simply pull it from Jina Cloud:
+First we load images. You can simply pull them from Jina Cloud:
 
 ```python
 from docarray import DocumentArray
@@ -156,7 +364,7 @@ da = DocumentArray.pull('ttl-original', show_progress=True, local_cache=True)
 <details>
 <summary>or download TTL dataset, unzip, load manually</summary>
 
-Alternatively, you can go to [Totally Looks Like](https://sites.google.com/view/totally-looks-like-dataset) official website, unzip and load images as follows:
+Alternatively, you can go to [Totally Looks Like](https://sites.google.com/view/totally-looks-like-dataset) official website, unzip and load images:
 
 ```python
 from docarray import DocumentArray
@@ -166,7 +374,7 @@ da = DocumentArray.from_files(['left/*.jpg', 'right/*.jpg'])
 
 </details>
 
-The dataset contains 12,032 images, hence it may take half minute to pull. Once done, you can visualize it and get the first taste of those images.
+The dataset contains 12,032 images, so it may take a while to pull. Once done, you can visualize it and get the first taste of those images:
 
 ```python
 da.plot_image_sprites()
@@ -178,23 +386,24 @@ da.plot_image_sprites()
 
 #### Encode images
 
-Start the server with `python -m clip_server`. Say it is at `87.191.159.105:51000` with `GRPC` protocol (you will get this information after running the server).
+Start the server with `python -m clip_server`. Let's say it's at `0.0.0.0:51000` with `GRPC` protocol (you will get this information after running the server).
 
 Create a Python client script:
+
 ```python
 from clip_client import Client
 
-c = Client(server='grpc://87.191.159.105:51000')
+c = Client(server='grpc://0.0.0.0:51000')
 
 da = c.encode(da, show_progress=True)
 ```
 
-Depending on your GPU and client-server network, it could take a while to embed 12K images. In my case, it takes ~2 minute.
+Depending on your GPU and client-server network, it may take a while to embed 12K images. In my case, it took about two minutes.
 
 <details>
 <summary>Download the pre-encoded dataset</summary>
 
-For people who are impatient or lack of GPU, waiting can be a hell. In this case, you can simply pull our pre-encoded image dataset.
+If you're impatient or don't have a GPU, waiting can be Hell. In this case, you can simply pull our pre-encoded image dataset:
 
 ```python
 from docarray import DocumentArray
@@ -206,18 +415,18 @@ da = DocumentArray.pull('ttl-embedding', show_progress=True, local_cache=True)
 
 #### Search via sentence 
 
-Let's build a simple prompt to allow user to type sentence:
+Let's build a simple prompt to allow a user to type sentence:
 
 ```python
 while True:
     vec = c.encode([input('sentence> ')])
     r = da.find(query=vec, limit=9)
-    r.plot_image_sprites()
+    r[0].plot_image_sprites()
 ```
 
 #### Showcase
 
-Now you can input arbitrary English sentences and view the top-9 matched images. Search is fast and instinct. Let's have some fun:
+Now you can input arbitrary English sentences and view the top-9 matching images. Search is fast and instinctive. Let's have some fun:
 
 <table>
 <tr>
@@ -326,12 +535,12 @@ da.summary()
 
 #### Encode sentences
 
-Now encode these 6403 sentences, it may take 10s or less depending on your GPU and network: 
+Now encode these 6,403 sentences, it may take 10 seconds or less depending on your GPU and network: 
 
 ```python
 from clip_client import Client
 
-c = Client('grpc://87.191.159.105:51000')
+c = Client('grpc://0.0.0.0:51000')
 
 r = c.encode(da, show_progress=True)
 ```
@@ -339,7 +548,7 @@ r = c.encode(da, show_progress=True)
 <details>
 <summary>Download the pre-encoded dataset</summary>
 
-Again, for people who are impatient or lack of GPU, we have prepared a pre-encoded text dataset.
+Again, for people who are impatient or don't have a GPU, we have prepared a pre-encoded text dataset:
 
 ```python
 from docarray import DocumentArray
@@ -351,7 +560,7 @@ da = DocumentArray.pull('ttl-textual', show_progress=True, local_cache=True)
 
 #### Search via image
 
-Let's load our previously stored image embedding; randomly sample image Document from it, then find top-1 nearest neighbour of each.
+Let's load our previously stored image embedding, randomly sample 10 image Documents, then find top-1 nearest neighbour of each.
 
 ```python
 from docarray import DocumentArray
@@ -364,7 +573,7 @@ for d in img_da.sample(10):
 
 #### Showcase
 
-Fun time! Note, unlike the previous example, here the input is an image, the sentence is the output. All sentences come from the book "Pride and Prejudice". 
+Fun time! Note, unlike the previous example, here the input is an image and the sentence is the output. All sentences come from the book "Pride and Prejudice". 
 
 <table>
 <tr>
@@ -463,14 +672,83 @@ Fun time! Note, unlike the previous example, here the input is an image, the sen
 </table>
 
 
-Intrigued? That's only scratching the surface of what CLIP-as-service is capable of. [Read our docs to learn more](https://clip-as-service.jina.ai).
 
+### Rank image-text matches via CLIP model
+
+From `0.3.0` CLIP-as-service adds a new `/rank` endpoint that re-ranks cross-modal matches according to their joint likelihood in CLIP model. For example, given an image Document with some predefined sentence matches as below:
+
+```python
+from clip_client import Client
+from docarray import Document
+
+c = Client(server='grpc://0.0.0.0:51000')
+r = c.rank(
+    [
+        Document(
+            uri='.github/README-img/rerank.png',
+            matches=[
+                Document(text=f'a photo of a {p}')
+                for p in (
+                    'control room',
+                    'lecture room',
+                    'conference room',
+                    'podium indoor',
+                    'television studio',
+                )
+            ],
+        )
+    ]
+)
+
+print(r['@m', ['text', 'scores__clip_score__value']])
+```
+
+```text
+[['a photo of a television studio', 'a photo of a conference room', 'a photo of a lecture room', 'a photo of a control room', 'a photo of a podium indoor'], 
+[0.9920725226402283, 0.006038925610482693, 0.0009973491542041302, 0.00078492151806131, 0.00010626466246321797]]
+```
+
+One can see now `a photo of a television studio` is ranked to the top with `clip_score` score at `0.992`. In practice, one can use this endpoint to re-rank the matching result from another search system, for improving the cross-modal search quality.
+
+<table>
+<tr>
+<td>
+<img src="https://github.com/jina-ai/clip-as-service/blob/main/.github/README-img/rerank.png?raw=true" alt="Rerank endpoint image input" height="150px">
+</td>
+<td>
+<img src="https://github.com/jina-ai/clip-as-service/blob/main/.github/README-img/rerank-chart.svg?raw=true" alt="Rerank endpoint output">
+</td>
+</tr>
+</table>
+
+### Rank text-image matches via CLIP model
+
+In the [DALL·E Flow](https://github.com/jina-ai/dalle-flow) project, CLIP is called for ranking the generated results from DALL·E. [It has an Executor wrapped on top of `clip-client`](https://github.com/jina-ai/dalle-flow/blob/main/executors/rerank/executor.py), which calls `.arank()` - the async version of `.rank()`:
+
+```python
+from clip_client import Client
+from jina import Executor, requests, DocumentArray
+
+
+class ReRank(Executor):
+    def __init__(self, clip_server: str, **kwargs):
+        super().__init__(**kwargs)
+        self._client = Client(server=clip_server)
+
+    @requests(on='/')
+    async def rerank(self, docs: DocumentArray, **kwargs):
+        return await self._client.arank(docs)
+```
+
+<p align="center">
+<img src="https://github.com/jina-ai/clip-as-service/blob/main/.github/README-img/client-dalle.png?raw=true" alt="CLIP-as-service used in DALLE Flow" width="300px">
+</p>
+
+Intrigued? That's only scratching the surface of what CLIP-as-service is capable of. [Read our docs to learn more](https://clip-as-service.jina.ai).
 
 <!-- start support-pitch -->
 ## Support
 
-- Use [Discussions](https://github.com/jina-ai/clip-as-service/discussions) to talk about your use cases, questions, and
-  support queries.
 - Join our [Slack community](https://slack.jina.ai) and chat with other community members about ideas.
 - Join our [Engineering All Hands](https://youtube.com/playlist?list=PL3UBBWOUVhFYRUa_gpYYKBqEAkO4sxmne) meet-up to discuss your use case and learn Jina's new features.
     - **When?** The second Tuesday of every month

--- a/client/setup.py
+++ b/client/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description_content_type='text/markdown',
     zip_safe=False,
     setup_requires=['setuptools>=18.0', 'wheel'],
-    install_requires=['jina>=3.8.0', 'docarray[common]>=0.16.1', 'packaging'],
+    install_requires=['jina>=3.11.0', 'docarray[common]>=0.19.0', 'packaging'],
     extras_require={
         'test': [
             'pytest',

--- a/client/setup.py
+++ b/client/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description_content_type='text/markdown',
     zip_safe=False,
     setup_requires=['setuptools>=18.0', 'wheel'],
-    install_requires=['jina>=3.11.0', 'docarray[common]>=0.19.0', 'packaging'],
+    install_requires=['jina>=3.12.0', 'docarray[common]>=0.19.0', 'packaging'],
     extras_require={
         'test': [
             'pytest',

--- a/server/clip_server/executors/clip_onnx.py
+++ b/server/clip_server/executors/clip_onnx.py
@@ -160,6 +160,10 @@ class CLIPEncoder(Executor):
                 split_img_txt_da(d, _img_da, _txt_da)
 
             with self.tracer.start_as_current_span('inference') as inference_span:
+                inference_span.set_attribute('drop_image_content', _drop_image_content)
+                inference_span.set_attribute('minibatch_size', self._minibatch_size)
+                inference_span.set_attribute('has_img_da', True if _img_da else False)
+                inference_span.set_attribute('has_txt_da', True if _txt_da else False)
                 # for image
                 if _img_da:
                     with self.tracer.start_as_current_span(

--- a/server/clip_server/executors/clip_onnx.py
+++ b/server/clip_server/executors/clip_onnx.py
@@ -15,6 +15,7 @@ from clip_server.model import clip
 from clip_server.model.clip_onnx import CLIPOnnxModel
 from clip_server.model.tokenization import Tokenizer
 from jina import Executor, requests, DocumentArray
+from opentelemetry.trace import NoOpTracer, Span
 
 
 class CLIPEncoder(Executor):
@@ -51,6 +52,7 @@ class CLIPEncoder(Executor):
             )
             self._access_paths = kwargs['traversal_paths']
 
+        self._num_worker_preprocess = num_worker_preprocess
         self._pool = ThreadPool(processes=num_worker_preprocess)
 
         self._model = CLIPOnnxModel(name, model_path)
@@ -100,24 +102,29 @@ class CLIPEncoder(Executor):
 
         self._model.start_sessions(sess_options=sess_options, providers=providers)
 
+        if not self.tracer:
+            self.tracer = NoOpTracer()
+
     def _preproc_images(self, docs: 'DocumentArray', drop_image_content: bool):
         with self.monitor(
             name='preprocess_images_seconds',
             documentation='images preprocess time in seconds',
         ):
-            return preproc_image(
-                docs,
-                preprocess_fn=self._image_transform,
-                return_np=True,
-                drop_image_content=drop_image_content,
-            )
+            with self.tracer.start_as_current_span('preprocess_images'):
+                return preproc_image(
+                    docs,
+                    preprocess_fn=self._image_transform,
+                    return_np=True,
+                    drop_image_content=drop_image_content,
+                )
 
     def _preproc_texts(self, docs: 'DocumentArray'):
         with self.monitor(
             name='preprocess_texts_seconds',
             documentation='texts preprocess time in seconds',
         ):
-            return preproc_text(docs, tokenizer=self._tokenizer, return_np=True)
+            with self.tracer.start_as_current_span('preprocess_images'):
+                return preproc_text(docs, tokenizer=self._tokenizer, return_np=True)
 
     @requests(on='/rank')
     async def rank(self, docs: 'DocumentArray', parameters: Dict, **kwargs):
@@ -127,44 +134,65 @@ class CLIPEncoder(Executor):
         set_rank(docs)
 
     @requests
-    async def encode(self, docs: 'DocumentArray', parameters: Dict = {}, **kwargs):
-        access_paths = parameters.get('access_paths', self._access_paths)
-        if 'traversal_paths' in parameters:
-            warnings.warn(
-                f'`traversal_paths` is deprecated. Use `access_paths` instead.'
-            )
-            access_paths = parameters['traversal_paths']
-        _drop_image_content = parameters.get('drop_image_content', False)
+    async def encode(
+        self, docs: 'DocumentArray', tracing_context, parameters: Dict = {}, **kwargs
+    ):
+        with self.tracer.start_as_current_span(
+            'encode', context=tracing_context
+        ) as span:
+            span.set_attribute('device', self._device)
+            span.set_attribute('runtime', 'onnx')
+            access_paths = parameters.get('access_paths', self._access_paths)
+            if 'traversal_paths' in parameters:
+                warnings.warn(
+                    f'`traversal_paths` is deprecated. Use `access_paths` instead.'
+                )
+                access_paths = parameters['traversal_paths']
+            _drop_image_content = parameters.get('drop_image_content', False)
 
-        _img_da = DocumentArray()
-        _txt_da = DocumentArray()
-        for d in docs[access_paths]:
-            split_img_txt_da(d, _img_da, _txt_da)
+            _img_da = DocumentArray()
+            _txt_da = DocumentArray()
+            for d in docs[access_paths]:
+                split_img_txt_da(d, _img_da, _txt_da)
 
-        # for image
-        if _img_da:
-            for minibatch, batch_data in _img_da.map_batch(
-                partial(self._preproc_images, drop_image_content=_drop_image_content),
-                batch_size=self._minibatch_size,
-                pool=self._pool,
-            ):
-                with self.monitor(
-                    name='encode_images_seconds',
-                    documentation='images encode time in seconds',
-                ):
-                    minibatch.embeddings = self._model.encode_image(batch_data)
+            with self.tracer.start_as_current_span('inference') as inference_span:
+                # for image
+                if _img_da:
+                    with self.tracer.start_as_current_span(
+                        'img_minibatch_encoding'
+                    ) as img_encode_span:
+                        for minibatch, batch_data in _img_da.map_batch(
+                            partial(
+                                self._preproc_images,
+                                drop_image_content=_drop_image_content,
+                            ),
+                            batch_size=self._minibatch_size,
+                            pool=self._pool,
+                        ):
+                            with self.monitor(
+                                name='encode_images_seconds',
+                                documentation='images encode time in seconds',
+                            ):
+                                minibatch.embeddings = self._model.encode_image(
+                                    batch_data
+                                )
 
-        # for text
-        if _txt_da:
-            for minibatch, batch_data in _txt_da.map_batch(
-                self._preproc_texts,
-                batch_size=self._minibatch_size,
-                pool=self._pool,
-            ):
-                with self.monitor(
-                    name='encode_texts_seconds',
-                    documentation='texts encode time in seconds',
-                ):
-                    minibatch.embeddings = self._model.encode_text(batch_data)
+                # for text
+                if _txt_da:
+                    with self.tracer.start_as_current_span(
+                        'txt_minibatch_encoding'
+                    ) as txt_encode_span:
+                        for minibatch, batch_data in _txt_da.map_batch(
+                            self._preproc_texts,
+                            batch_size=self._minibatch_size,
+                            pool=self._pool,
+                        ):
+                            with self.monitor(
+                                name='encode_texts_seconds',
+                                documentation='texts encode time in seconds',
+                            ):
+                                minibatch.embeddings = self._model.encode_text(
+                                    batch_data
+                                )
 
         return docs

--- a/server/clip_server/executors/clip_onnx.py
+++ b/server/clip_server/executors/clip_onnx.py
@@ -1,20 +1,20 @@
 import os
 import warnings
-from multiprocessing.pool import ThreadPool
-from typing import Optional, Dict
 from functools import partial
+from multiprocessing.pool import ThreadPool
+from typing import Dict, Optional
 
 import onnxruntime as ort
 from clip_server.executors.helper import (
-    split_img_txt_da,
     preproc_image,
     preproc_text,
     set_rank,
+    split_img_txt_da,
 )
 from clip_server.model import clip
 from clip_server.model.clip_onnx import CLIPOnnxModel
 from clip_server.model.tokenization import Tokenizer
-from jina import Executor, requests, DocumentArray
+from jina import DocumentArray, Executor, requests
 from opentelemetry.trace import NoOpTracer, Span
 
 
@@ -135,7 +135,11 @@ class CLIPEncoder(Executor):
 
     @requests
     async def encode(
-        self, docs: 'DocumentArray', tracing_context, parameters: Dict = {}, **kwargs
+        self,
+        docs: 'DocumentArray',
+        tracing_context=None,
+        parameters: Dict = {},
+        **kwargs,
     ):
         with self.tracer.start_as_current_span(
             'encode', context=tracing_context

--- a/server/clip_server/executors/clip_tensorrt.py
+++ b/server/clip_server/executors/clip_tensorrt.py
@@ -134,6 +134,10 @@ class CLIPEncoder(Executor):
                 split_img_txt_da(d, _img_da, _txt_da)
 
             with self.tracer.start_as_current_span('inference') as inference_span:
+                inference_span.set_attribute('drop_image_content', _drop_image_content)
+                inference_span.set_attribute('minibatch_size', self._minibatch_size)
+                inference_span.set_attribute('has_img_da', True if _img_da else False)
+                inference_span.set_attribute('has_txt_da', True if _txt_da else False)
                 # for image
                 if _img_da:
                     with self.tracer.start_as_current_span(

--- a/server/clip_server/executors/clip_tensorrt.py
+++ b/server/clip_server/executors/clip_tensorrt.py
@@ -1,19 +1,19 @@
 import warnings
-from multiprocessing.pool import ThreadPool
-from typing import Optional, Dict
 from functools import partial
+from multiprocessing.pool import ThreadPool
+from typing import Dict, Optional
 
 import numpy as np
 from clip_server.executors.helper import (
-    split_img_txt_da,
     preproc_image,
     preproc_text,
     set_rank,
+    split_img_txt_da,
 )
 from clip_server.model import clip
-from clip_server.model.tokenization import Tokenizer
 from clip_server.model.clip_trt import CLIPTensorRTModel
-from jina import Executor, requests, DocumentArray
+from clip_server.model.tokenization import Tokenizer
+from jina import DocumentArray, Executor, requests
 from opentelemetry.trace import NoOpTracer, Span
 
 
@@ -109,7 +109,11 @@ class CLIPEncoder(Executor):
 
     @requests
     async def encode(
-        self, docs: 'DocumentArray', tracing_context, parameters: Dict = {}, **kwargs
+        self,
+        docs: 'DocumentArray',
+        tracing_context=None,
+        parameters: Dict = {},
+        **kwargs,
     ):
         with self.tracer.start_as_current_span(
             'encode', context=tracing_context

--- a/server/clip_server/executors/clip_torch.py
+++ b/server/clip_server/executors/clip_torch.py
@@ -3,6 +3,7 @@ import warnings
 from multiprocessing.pool import ThreadPool
 from typing import Optional, Dict
 from functools import partial
+from opentelemetry.trace import NoOpTracer, Span
 
 import numpy as np
 import torch
@@ -72,33 +73,43 @@ class CLIPEncoder(Executor):
             # For more details, please see https://pytorch.org/docs/stable/generated/torch.set_num_threads.html
             torch.set_num_threads(max(num_threads, 1))
             torch.set_num_interop_threads(1)
+
+        self._num_worker_preprocess = num_worker_preprocess
         self._pool = ThreadPool(processes=num_worker_preprocess)
 
         self._model = CLIPModel(name, device=self._device, jit=jit, **kwargs)
         self._tokenizer = Tokenizer(name)
         self._image_transform = clip._transform_ndarray(self._model.image_size)
 
+        if not self.tracer:
+            self.tracer = NoOpTracer()
+
     def _preproc_images(self, docs: 'DocumentArray', drop_image_content: bool):
         with self.monitor(
             name='preprocess_images_seconds',
             documentation='images preprocess time in seconds',
         ):
-            return preproc_image(
-                docs,
-                preprocess_fn=self._image_transform,
-                device=self._device,
-                return_np=False,
-                drop_image_content=drop_image_content,
-            )
+            with self.tracer.start_as_current_span('preprocess_images'):
+                return preproc_image(
+                    docs,
+                    preprocess_fn=self._image_transform,
+                    device=self._device,
+                    return_np=False,
+                    drop_image_content=drop_image_content,
+                )
 
     def _preproc_texts(self, docs: 'DocumentArray'):
         with self.monitor(
             name='preprocess_texts_seconds',
             documentation='texts preprocess time in seconds',
         ):
-            return preproc_text(
-                docs, tokenizer=self._tokenizer, device=self._device, return_np=False
-            )
+            with self.tracer.start_as_current_span('preprocess_images'):
+                return preproc_text(
+                    docs,
+                    tokenizer=self._tokenizer,
+                    device=self._device,
+                    return_np=False,
+                )
 
     @requests(on='/rank')
     async def rank(self, docs: 'DocumentArray', parameters: Dict, **kwargs):
@@ -108,57 +119,88 @@ class CLIPEncoder(Executor):
         set_rank(docs)
 
     @requests
-    async def encode(self, docs: 'DocumentArray', parameters: Dict = {}, **kwargs):
-        access_paths = parameters.get('access_paths', self._access_paths)
-        if 'traversal_paths' in parameters:
-            warnings.warn(
-                f'`traversal_paths` is deprecated. Use `access_paths` instead.'
-            )
-            access_paths = parameters['traversal_paths']
-        _drop_image_content = parameters.get('drop_image_content', False)
+    async def encode(
+        self, docs: 'DocumentArray', tracing_context, parameters: Dict = {}, **kwargs
+    ):
+        with self.tracer.start_as_current_span(
+            'encode', context=tracing_context
+        ) as span:
+            span.set_attribute('device', self._device)
+            span.set_attribute('runtime', 'torch')
+            access_paths = parameters.get('access_paths', self._access_paths)
+            if 'traversal_paths' in parameters:
+                warnings.warn(
+                    f'`traversal_paths` is deprecated. Use `access_paths` instead.'
+                )
+                access_paths = parameters['traversal_paths']
+            _drop_image_content = parameters.get('drop_image_content', False)
 
-        _img_da = DocumentArray()
-        _txt_da = DocumentArray()
-        for d in docs[access_paths]:
-            split_img_txt_da(d, _img_da, _txt_da)
+            _img_da = DocumentArray()
+            _txt_da = DocumentArray()
+            for d in docs[access_paths]:
+                split_img_txt_da(d, _img_da, _txt_da)
 
-        with torch.inference_mode():
-            # for image
-            if _img_da:
-                for minibatch, batch_data in _img_da.map_batch(
-                    partial(
-                        self._preproc_images, drop_image_content=_drop_image_content
-                    ),
-                    batch_size=self._minibatch_size,
-                    pool=self._pool,
-                ):
-                    with self.monitor(
-                        name='encode_images_seconds',
-                        documentation='images encode time in seconds',
-                    ):
-                        minibatch.embeddings = (
-                            self._model.encode_image(**batch_data)
-                            .cpu()
-                            .numpy()
-                            .astype(np.float32)
-                        )
+            with self.tracer.start_as_current_span('inference') as inference_span:
+                with torch.inference_mode():
+                    inference_span.set_attribute(
+                        'drop_image_content', _drop_image_content
+                    )
+                    inference_span.set_attribute('minibatch_size', self._minibatch_size)
+                    inference_span.set_attribute(
+                        'has_img_da', True if _img_da else False
+                    )
+                    inference_span.set_attribute(
+                        'has_txt_da', True if _txt_da else False
+                    )
+                    # for image
+                    if _img_da:
+                        with self.tracer.start_as_current_span(
+                            'img_minibatch_encoding'
+                        ) as img_encode_span:
+                            img_encode_span.set_attribute(
+                                'num_pool_workers', self._num_worker_preprocess
+                            )
+                            for minibatch, batch_data in _img_da.map_batch(
+                                partial(
+                                    self._preproc_images,
+                                    drop_image_content=_drop_image_content,
+                                ),
+                                batch_size=self._minibatch_size,
+                                pool=self._pool,
+                            ):
+                                with self.monitor(
+                                    name='encode_images_seconds',
+                                    documentation='images encode time in seconds',
+                                ):
+                                    minibatch.embeddings = (
+                                        self._model.encode_image(**batch_data)
+                                        .cpu()
+                                        .numpy()
+                                        .astype(np.float32)
+                                    )
 
-            # for text
-            if _txt_da:
-                for minibatch, batch_data in _txt_da.map_batch(
-                    self._preproc_texts,
-                    batch_size=self._minibatch_size,
-                    pool=self._pool,
-                ):
-                    with self.monitor(
-                        name='encode_texts_seconds',
-                        documentation='texts encode time in seconds',
-                    ):
-                        minibatch.embeddings = (
-                            self._model.encode_text(**batch_data)
-                            .cpu()
-                            .numpy()
-                            .astype(np.float32)
-                        )
+                    # for text
+                    if _txt_da:
+                        with self.tracer.start_as_current_span(
+                            'txt_minibatch_encoding'
+                        ) as txt_encode_span:
+                            txt_encode_span.set_attribute(
+                                'num_pool_workers', self._num_worker_preprocess
+                            )
+                            for minibatch, batch_data in _txt_da.map_batch(
+                                self._preproc_texts,
+                                batch_size=self._minibatch_size,
+                                pool=self._pool,
+                            ):
+                                with self.monitor(
+                                    name='encode_texts_seconds',
+                                    documentation='texts encode time in seconds',
+                                ):
+                                    minibatch.embeddings = (
+                                        self._model.encode_text(**batch_data)
+                                        .cpu()
+                                        .numpy()
+                                        .astype(np.float32)
+                                    )
 
         return docs

--- a/server/clip_server/executors/clip_torch.py
+++ b/server/clip_server/executors/clip_torch.py
@@ -1,22 +1,22 @@
 import os
 import warnings
-from multiprocessing.pool import ThreadPool
-from typing import Optional, Dict
 from functools import partial
-from opentelemetry.trace import NoOpTracer, Span
+from multiprocessing.pool import ThreadPool
+from typing import Dict, Optional
 
 import numpy as np
 import torch
 from clip_server.executors.helper import (
-    split_img_txt_da,
     preproc_image,
     preproc_text,
     set_rank,
+    split_img_txt_da,
 )
 from clip_server.model import clip
 from clip_server.model.clip_model import CLIPModel
 from clip_server.model.tokenization import Tokenizer
-from jina import Executor, requests, DocumentArray
+from jina import DocumentArray, Executor, requests
+from opentelemetry.trace import NoOpTracer, Span
 
 
 class CLIPEncoder(Executor):
@@ -120,7 +120,11 @@ class CLIPEncoder(Executor):
 
     @requests
     async def encode(
-        self, docs: 'DocumentArray', tracing_context, parameters: Dict = {}, **kwargs
+        self,
+        docs: 'DocumentArray',
+        tracing_context=None,
+        parameters: Dict = {},
+        **kwargs,
     ):
         with self.tracer.start_as_current_span(
             'encode', context=tracing_context

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,8 +1,7 @@
 import sys
 from os import path
 
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 if sys.version_info < (3, 7, 0):
     raise OSError(f'CLIP-as-service requires Python >=3.7, but yours is {sys.version}')
@@ -46,7 +45,7 @@ setup(
         'torch',
         'regex',
         'torchvision<=0.13.0' if sys.version_info <= (3, 7, 2) else 'torchvision',
-        'jina>=3.8.0',
+        'jina>=3.12.0',
         'prometheus-client',
         'open_clip_torch>=1.3.0',
     ],


### PR DESCRIPTION
Goals:
- [x] update to jina>=3.12.0
- [x] update Executors with tracing support:
  - [x] add `NoOpTracer` if tracing is disabled so that the operations with `self.tracer` become no-op code. The `NoOpTracer` is part of the `opentelemetry-api` library downloaded by jina `standard` requirements.
  - [x] add new spans to measure various operations in the `encode` requests method.
  - [ ] more customizations/spans if needed.
- [ ] update documentation for Executors. 

I will post a link to the completed Blog so that the usage of tracing is clear.