### PR TITLE
chore: fix configuration file for the search flow

### DIFF
--- a/docs/user-guides/retriever.md
+++ b/docs/user-guides/retriever.md
@@ -47,7 +47,6 @@ executors:
   - name: encoder
     uses:
       jtype: CLIPEncoder
-      with:
       metas:
         py_modules:
           - clip_server.executors.clip_torch


### PR DESCRIPTION
del null key.
otherwise，U will get this error. 
`TypeError: clip_server.executors.clip_torch.CLIPEncoder() argument after ** must be a mapping, not NoneType.`
