### PR TITLE
fix: check if results are empty

### DIFF
--- a/client/clip_client/client.py
+++ b/client/clip_client/client.py
@@ -165,7 +165,7 @@ class Client:
         response, results: 'DocumentArray', attribute: Optional[str] = None
     ):
         r = response.data.docs
-        if attribute:
+        if attribute and len(r) > 0:
             results[r[:, 'id']][:, attribute] = r[:, attribute]
 
     def _iter_doc(


### PR DESCRIPTION
Fixing encoding of a dataset using cas.
To reproduce:
download this file https://jinaai.slack.com/files/U026WRMRL6A/F04GE6JKX0U/dataset.csv

then:
```
from docarray import DocumentArray, Document
with open('dataset.csv') as fp:
  da = DocumentArray.from_csv(fp)

from clip_client import Client

c = Client(
    'grpcs://api.clip.jina.ai:2096', credential={'Authorization': 'atuh-token'}
)

encoded_da = c.encode(da, show_progress=True)
```