### PR TITLE
fix: onnx package conflict during setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
           python -m pip install wheel pytest pytest-cov nvidia-pyindex
           pip install -e "client/[test]"
           pip install -e "server/[tensorrt]"
+          pip install -e "server/[onnx]"
           pip install -e "server/[transformers]"
           {
             pip install -e "server/[flash-attn]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
 
-  gpu-test:
+  trt-gpu-test:
     needs: prep-testbed
     runs-on: [self-hosted, x64, gpu, linux]
     strategy:
@@ -158,7 +158,6 @@ jobs:
           python -m pip install wheel pytest pytest-cov nvidia-pyindex
           pip install -e "client/[test]"
           pip install -e "server/[tensorrt]"
-          pip install -e "server/[onnx]"
           pip install -e "server/[transformers]"
           {
             pip install -e "server/[flash-attn]"
@@ -173,6 +172,58 @@ jobs:
             -v -s -m "gpu" ./tests/test_tensorrt.py
           pytest --suppress-no-test-exit-code --cov=clip_client --cov=clip_server --cov-report=xml \
             -v -s -m "gpu" ./tests/test_simple.py
+          echo "::set-output name=codecov_flag::cas"
+        timeout-minutes: 30
+        env:
+          # fix re-initialized torch runtime error on cuda device
+          JINA_MP_START_METHOD: spawn
+      - name: Check codecov file
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "coverage.xml"
+      - name: Upload coverage from test to Codecov
+        uses: codecov/codecov-action@v3
+        if: steps.check_files.outputs.files_exists == 'true' && ${{ matrix.python-version }} == '3.7'
+        with:
+          file: coverage.xml
+          name: gpu-related-codecov
+          flags: ${{ steps.test.outputs.codecov_flag }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+
+  gpu-model-test:
+    needs: prep-testbed
+    runs-on: [ self-hosted, x64, gpu, linux ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ 3.7 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # For coverage builds fetch the whole history
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel pytest pytest-cov nvidia-pyindex
+          pip install -e "client/[test]"
+          pip install -e "server/[onnx]"
+          pip install -e "server/[transformers]"
+          {
+            pip install -e "server/[flash-attn]"
+          } || {
+            echo "flash attention was not installed."
+          }
+          pip install --no-cache-dir "server/[cn_clip]"
+      - name: Test
+        id: test
+        run: |
           pytest --suppress-no-test-exit-code --cov=clip_client --cov=clip_server --cov-report=xml \
             -v -s -m "gpu" ./tests/test_model.py
           echo "::set-output name=codecov_flag::cas"
@@ -197,7 +248,7 @@ jobs:
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
-    needs: [commit-lint, core-test, gpu-test]
+    needs: [commit-lint, core-test, trt-gpu-test, gpu-model-test]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/user-guides/server.md
+++ b/docs/user-guides/server.md
@@ -591,9 +591,21 @@ The build argument `--build-arg GROUP_ID=$(id -g ${USER}) --build-arg USER_ID=$(
 
 ### Run
 
+````{tab} PyTorch
 ```bash
 docker run -p 51009:51000 -v $HOME/.cache:/home/cas/.cache --gpus all jinaai/clip-server
 ```
+````
+````{tab} ONNX
+```bash
+docker run -p 51009:51000 -v $HOME/.cache:/home/cas/.cache --gpus all jinaai/clip-server:master-onnx onnx-flow.yml
+```
+````
+````{tab} TensorRT
+```bash
+docker run -p 51009:51000 -v $HOME/.cache:/home/cas/.cache --gpus all jinaai/clip-server:master-tensorrt tensorrt-flow.yml
+```
+````
 
 Here, `51009` is the public port on the host and `51000` is the {ref}`in-container port defined inside YAML<flow-config>`. The argument `-v $HOME/.cache:/home/cas/.cache` leverages host's cache and prevents you to download the same model next time on start. 
 
@@ -601,11 +613,23 @@ Due to the limitation of the terminal inside Docker container, you will **not** 
 
 To pass a YAML config from the host, one can do:
 
+````{tab} PyTorch
 ```bash
 cat my.yml | docker run -i -p 51009:51000 -v $HOME/.cache:/home/cas/.cache --gpus all jinaai/clip-server -i
 ```
+````
+````{tab} ONNX
+```bash
+cat my.yml | docker run -i -p 51009:51000 -v $HOME/.cache:/home/cas/.cache --gpus all jinaai/clip-server:master-onnx -i
+```
+````
+````{tab} TensorRT
+```bash
+cat my.yml | docker run -i -p 51009:51000 -v $HOME/.cache:/home/cas/.cache --gpus all jinaai/clip-server:master-tensorrt -i
+```
+````
 
-The CLI usage is the same {ref}`as described here <start-server>`.
+The CLI usage is the same {ref}`as described here <server-address>`.
 
 ```{tip}
 You can enable debug logging via: `docker run --env JINA_LOG_LEVEL=debug ...`

--- a/server/setup.py
+++ b/server/setup.py
@@ -53,8 +53,9 @@ setup(
         'onnx': [
             'onnx',
             'onnxmltools',
+            'onnxruntime',
         ]
-        + (['onnxruntime-gpu>=1.8.0'] if sys.platform != 'darwin' else ['onnxruntime']),
+        + (['onnxruntime-gpu>=1.8.0'] if sys.platform != 'darwin' else []),
         'tensorrt': ['nvidia-tensorrt'],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -51,9 +51,9 @@ setup(
     ],
     extras_require={
         'onnx': [
+            'onnxruntime==1.13.1',
             'onnx',
             'onnxmltools',
-            'onnxruntime==1.13.1',
         ]
         + (['onnxruntime-gpu==1.13.1'] if sys.platform != 'darwin' else []),
         'tensorrt': [

--- a/server/setup.py
+++ b/server/setup.py
@@ -53,14 +53,13 @@ setup(
         'onnx': [
             'onnx',
             'onnxmltools',
-            'onnxruntime==1.13.1',
-        ],
-        # + (
-        #     ['onnxruntime-gpu==1.13.1']
-        #     if sys.platform != 'darwin'
-        #     else ['onnxruntime==1.13.1']
-        # ),
-        'tensorrt': ['nvidia-tensorrt'],
+        ]
+        + (
+            ['onnxruntime-gpu==1.13.1']
+            if sys.platform != 'darwin'
+            else ['onnxruntime==1.13.1']
+        ),
+        'tensorrt': ['onnx', 'onnxmltools', 'onnxruntime==1.13.1', 'nvidia-tensorrt'],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],
         'flash-attn': ['flash-attn'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -53,12 +53,13 @@ setup(
         'onnx': [
             'onnx',
             'onnxmltools',
-        ]
-        + (
-            ['onnxruntime-gpu==1.13.1']
-            if sys.platform != 'darwin'
-            else ['onnxruntime==1.13.1']
-        ),
+            'onnxruntime==1.13.1',
+        ],
+        # + (
+        #     ['onnxruntime-gpu==1.13.1']
+        #     if sys.platform != 'darwin'
+        #     else ['onnxruntime==1.13.1']
+        # ),
         'tensorrt': ['nvidia-tensorrt'],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -55,9 +55,9 @@ setup(
             'onnxmltools',
         ]
         + (
-            ['onnxruntime-gpu==1.13.1']
+            ['onnxruntime-gpu<=1.13.1']
             if sys.platform != 'darwin'
-            else ['onnxruntime==1.13.1']
+            else ['onnxruntime<=1.13.1']
         ),
         'tensorrt': [
             'nvidia-tensorrt==8.4.1.5',

--- a/server/setup.py
+++ b/server/setup.py
@@ -62,6 +62,7 @@ setup(
         'tensorrt': [
             'onnx',
             'onnxmltools',
+            'onnxruntime==1.13.1',
             'onnxruntime-gpu==1.13.1',
             'nvidia-tensorrt',
         ],

--- a/server/setup.py
+++ b/server/setup.py
@@ -53,9 +53,8 @@ setup(
         'onnx': [
             'onnx',
             'onnxmltools',
-            'onnxruntime',
         ]
-        + (['onnxruntime-gpu>=1.8.0'] if sys.platform != 'darwin' else []),
+        + (['onnxruntime-gpu>=1.8.0'] if sys.platform != 'darwin' else ['onnxruntime']),
         'tensorrt': ['nvidia-tensorrt'],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -61,7 +61,7 @@ setup(
         ),
         'tensorrt': [
             'nvidia-tensorrt',
-            # 'onnxruntime==1.13.1',
+            'onnxruntime==1.13.1',
             # 'onnx',
             # 'onnxmltools',
         ],

--- a/server/setup.py
+++ b/server/setup.py
@@ -61,9 +61,9 @@ setup(
         ),
         'tensorrt': [
             'nvidia-tensorrt',
-            'onnxruntime==1.13.1',
-            'onnx',
-            'onnxmltools',
+            # 'onnxruntime==1.13.1',
+            # 'onnx',
+            # 'onnxmltools',
         ],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -60,11 +60,10 @@ setup(
             else ['onnxruntime==1.13.1']
         ),
         'tensorrt': [
+            'nvidia-tensorrt',
+            'onnxruntime==1.13.1',
             'onnx',
             'onnxmltools',
-            'onnxruntime==1.13.1',
-            'onnxruntime-gpu==1.13.1',
-            'nvidia-tensorrt',
         ],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -53,15 +53,16 @@ setup(
         'onnx': [
             'onnx',
             'onnxmltools',
+            'onnxruntime==1.13.1',
         ]
         + (
             ['onnxruntime-gpu==1.13.1']
             if sys.platform != 'darwin'
-            else ['onnxruntime==1.13.1']
+            else []
         ),
         'tensorrt': [
             'nvidia-tensorrt',
-            'onnxruntime==1.13.1',
+            # 'onnxruntime==1.13.1',
             # 'onnx',
             # 'onnxmltools',
         ],

--- a/server/setup.py
+++ b/server/setup.py
@@ -51,11 +51,10 @@ setup(
     ],
     extras_require={
         'onnx': [
-            'onnxruntime',
             'onnx',
             'onnxmltools',
         ]
-        + (['onnxruntime-gpu>=1.8.0'] if sys.platform != 'darwin' else []),
+        + (['onnxruntime-gpu>=1.8.0'] if sys.platform != 'darwin' else ['onnxruntime']),
         'tensorrt': ['nvidia-tensorrt'],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -54,7 +54,11 @@ setup(
             'onnx',
             'onnxmltools',
         ]
-        + (['onnxruntime-gpu>=1.8.0'] if sys.platform != 'darwin' else ['onnxruntime']),
+        + (
+            ['onnxruntime-gpu==1.13.1']
+            if sys.platform != 'darwin'
+            else ['onnxruntime==1.13.1']
+        ),
         'tensorrt': ['nvidia-tensorrt'],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -53,9 +53,13 @@ setup(
         'onnx': [
             'onnx',
             'onnxmltools',
-            'onnxruntime==1.13.1',
-        ],
-        # + (['onnxruntime-gpu==1.13.1'] if sys.platform != 'darwin' else []),
+            # 'onnxruntime==1.13.1',
+        ]
+        + (
+            ['onnxruntime-gpu==1.13.1']
+            if sys.platform != 'darwin'
+            else ['onnxruntime==1.13.1']
+        ),
         'tensorrt': [
             'nvidia-tensorrt==8.4.1.5',
             # 'onnxruntime==1.13.1',

--- a/server/setup.py
+++ b/server/setup.py
@@ -54,11 +54,7 @@ setup(
             'onnx',
             'onnxmltools',
         ]
-        + (
-            ['onnxruntime-gpu<=1.13.1']
-            if sys.platform != 'darwin'
-            else ['onnxruntime<=1.13.1']
-        ),
+        + (['onnxruntime-gpu'] if sys.platform != 'darwin' else ['onnxruntime']),
         'tensorrt': [
             'nvidia-tensorrt==8.4.1.5',
         ],

--- a/server/setup.py
+++ b/server/setup.py
@@ -51,11 +51,11 @@ setup(
     ],
     extras_require={
         'onnx': [
-            'onnxruntime==1.13.1',
             'onnx',
             'onnxmltools',
-        ]
-        + (['onnxruntime-gpu==1.13.1'] if sys.platform != 'darwin' else []),
+            'onnxruntime==1.13.1',
+        ],
+        # + (['onnxruntime-gpu==1.13.1'] if sys.platform != 'darwin' else []),
         'tensorrt': [
             'nvidia-tensorrt',
             # 'onnxruntime==1.13.1',

--- a/server/setup.py
+++ b/server/setup.py
@@ -54,7 +54,11 @@ setup(
             'onnx',
             'onnxmltools',
         ]
-        + (['onnxruntime-gpu'] if sys.platform != 'darwin' else ['onnxruntime']),
+        + (
+            ['onnxruntime-gpu<=1.13.1']
+            if sys.platform != 'darwin'
+            else ['onnxruntime<=1.13.1']
+        ),
         'tensorrt': [
             'nvidia-tensorrt==8.4.1.5',
         ],

--- a/server/setup.py
+++ b/server/setup.py
@@ -57,7 +57,7 @@ setup(
         ],
         # + (['onnxruntime-gpu==1.13.1'] if sys.platform != 'darwin' else []),
         'tensorrt': [
-            'nvidia-tensorrt',
+            'nvidia-tensorrt==8.4.1.5',
             # 'onnxruntime==1.13.1',
             # 'onnx',
             # 'onnxmltools',

--- a/server/setup.py
+++ b/server/setup.py
@@ -59,7 +59,12 @@ setup(
             if sys.platform != 'darwin'
             else ['onnxruntime==1.13.1']
         ),
-        'tensorrt': ['onnx', 'onnxmltools', 'onnxruntime==1.13.1', 'nvidia-tensorrt'],
+        'tensorrt': [
+            'onnx',
+            'onnxmltools',
+            'onnxruntime-gpu==1.13.1',
+            'nvidia-tensorrt',
+        ],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],
         'flash-attn': ['flash-attn'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -53,7 +53,6 @@ setup(
         'onnx': [
             'onnx',
             'onnxmltools',
-            # 'onnxruntime==1.13.1',
         ]
         + (
             ['onnxruntime-gpu==1.13.1']
@@ -62,9 +61,6 @@ setup(
         ),
         'tensorrt': [
             'nvidia-tensorrt==8.4.1.5',
-            # 'onnxruntime==1.13.1',
-            # 'onnx',
-            # 'onnxmltools',
         ],
         'transformers': ['transformers>=4.16.2'],
         'search': ['annlite>=0.3.10'],

--- a/server/setup.py
+++ b/server/setup.py
@@ -55,11 +55,7 @@ setup(
             'onnxmltools',
             'onnxruntime==1.13.1',
         ]
-        + (
-            ['onnxruntime-gpu==1.13.1']
-            if sys.platform != 'darwin'
-            else []
-        ),
+        + (['onnxruntime-gpu==1.13.1'] if sys.platform != 'darwin' else []),
         'tensorrt': [
             'nvidia-tensorrt',
             # 'onnxruntime==1.13.1',

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -26,7 +26,7 @@ async def test_async_encode(make_flow):
         DocumentArray(
             [
                 Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     text='hello, world',
                 ),
             ]

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -26,7 +26,7 @@ async def test_async_encode(make_flow):
         DocumentArray(
             [
                 Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                    uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     text='hello, world',
                 ),
             ]

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -32,10 +32,10 @@ def test_numpy_softmax(shape, axis):
                     Document(text='goodbye, world'),
                     Document(
                         text='hello, world',
-                        uri='https://docarray.jina.ai/_static/favicon.png',
+                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     ),
                     Document(
-                        uri='https://docarray.jina.ai/_static/favicon.png',
+                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     ),
                 ]
             ),
@@ -47,14 +47,14 @@ def test_numpy_softmax(shape, axis):
                     Document(text='hello, world'),
                     Document(tensor=np.array([0, 1, 2])),
                     Document(
-                        uri='https://docarray.jina.ai/_static/favicon.png'
+                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
                     ).load_uri_to_blob(),
                     Document(
                         tensor=np.array([0, 1, 2]),
-                        uri='https://docarray.jina.ai/_static/favicon.png',
+                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     ),
                     Document(
-                        uri='https://docarray.jina.ai/_static/favicon.png',
+                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     ),
                 ]
             ),
@@ -64,7 +64,9 @@ def test_numpy_softmax(shape, axis):
             DocumentArray(
                 [
                     Document(text='hello, world'),
-                    Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                    Document(
+                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                    ),
                 ]
             ),
             (1, 1),
@@ -86,7 +88,7 @@ def test_split_img_txt_da(inputs):
         DocumentArray(
             [
                 Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                 ).load_uri_to_blob(),
             ]
         )

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -32,10 +32,10 @@ def test_numpy_softmax(shape, axis):
                     Document(text='goodbye, world'),
                     Document(
                         text='hello, world',
-                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                        uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     ),
                     Document(
-                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                        uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     ),
                 ]
             ),
@@ -47,14 +47,14 @@ def test_numpy_softmax(shape, axis):
                     Document(text='hello, world'),
                     Document(tensor=np.array([0, 1, 2])),
                     Document(
-                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                        uri='https://clip-as-service.jina.ai/_static/favicon.png'
                     ).load_uri_to_blob(),
                     Document(
                         tensor=np.array([0, 1, 2]),
-                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                        uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     ),
                     Document(
-                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                        uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     ),
                 ]
             ),
@@ -64,9 +64,7 @@ def test_numpy_softmax(shape, axis):
             DocumentArray(
                 [
                     Document(text='hello, world'),
-                    Document(
-                        uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
-                    ),
+                    Document(uri='https://clip-as-service.jina.ai/_static/favicon.png'),
                 ]
             ),
             (1, 1),
@@ -88,7 +86,7 @@ def test_split_img_txt_da(inputs):
         DocumentArray(
             [
                 Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                    uri='https://clip-as-service.jina.ai/_static/favicon.png',
                 ).load_uri_to_blob(),
             ]
         )

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -68,14 +68,14 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
     [
         [
             Document(
-                uri='https://docarray.jina.ai/_static/favicon.png',
+                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
                 ],
             ),
             Document(
-                uri='https://docarray.jina.ai/_static/favicon.png',
+                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
@@ -85,14 +85,14 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
         DocumentArray(
             [
                 Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     matches=[
                         Document(text='hello, world'),
                         Document(text='goodbye, world'),
                     ],
                 ),
                 Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     matches=[
                         Document(text='hello, world'),
                         Document(text='goodbye, world'),
@@ -102,7 +102,7 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
         ),
         lambda: (
             Document(
-                uri='https://docarray.jina.ai/_static/favicon.png',
+                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
@@ -115,7 +115,9 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
                 Document(
                     text='hello, world',
                     matches=[
-                        Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                        Document(
+                            uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                        ),
                         Document(
                             uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                         ),
@@ -144,7 +146,7 @@ def test_docarray_inputs(make_flow, inputs):
     [
         [
             Document(
-                uri='https://docarray.jina.ai/_static/favicon.png',
+                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
@@ -154,7 +156,7 @@ def test_docarray_inputs(make_flow, inputs):
         DocumentArray(
             [
                 Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     matches=[
                         Document(text='hello, world'),
                         Document(text='goodbye, world'),
@@ -164,7 +166,7 @@ def test_docarray_inputs(make_flow, inputs):
         ),
         lambda: (
             Document(
-                uri='https://docarray.jina.ai/_static/favicon.png',
+                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
@@ -177,7 +179,9 @@ def test_docarray_inputs(make_flow, inputs):
                 Document(
                     text='hello, world',
                     matches=[
-                        Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                        Document(
+                            uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                        ),
                         Document(
                             uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                         ),

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -68,14 +68,14 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
     [
         [
             Document(
-                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                uri='https://clip-as-service.jina.ai/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
                 ],
             ),
             Document(
-                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                uri='https://clip-as-service.jina.ai/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
@@ -85,14 +85,14 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
         DocumentArray(
             [
                 Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                    uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     matches=[
                         Document(text='hello, world'),
                         Document(text='goodbye, world'),
                     ],
                 ),
                 Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                    uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     matches=[
                         Document(text='hello, world'),
                         Document(text='goodbye, world'),
@@ -102,7 +102,7 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
         ),
         lambda: (
             Document(
-                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                uri='https://clip-as-service.jina.ai/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
@@ -116,7 +116,7 @@ async def test_torch_executor_rank_text2imgs(encoder_class):
                     text='hello, world',
                     matches=[
                         Document(
-                            uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                            uri='https://clip-as-service.jina.ai/_static/favicon.png'
                         ),
                         Document(
                             uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
@@ -146,7 +146,7 @@ def test_docarray_inputs(make_flow, inputs):
     [
         [
             Document(
-                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                uri='https://clip-as-service.jina.ai/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
@@ -156,7 +156,7 @@ def test_docarray_inputs(make_flow, inputs):
         DocumentArray(
             [
                 Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                    uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     matches=[
                         Document(text='hello, world'),
                         Document(text='goodbye, world'),
@@ -166,7 +166,7 @@ def test_docarray_inputs(make_flow, inputs):
         ),
         lambda: (
             Document(
-                uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                uri='https://clip-as-service.jina.ai/_static/favicon.png',
                 matches=[
                     Document(text='hello, world'),
                     Document(text='goodbye, world'),
@@ -180,7 +180,7 @@ def test_docarray_inputs(make_flow, inputs):
                     text='hello, world',
                     matches=[
                         Document(
-                            uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                            uri='https://clip-as-service.jina.ai/_static/favicon.png'
                         ),
                         Document(
                             uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,7 +15,9 @@ from clip_client import Client
         lambda: (Document(text='hello, world') for _ in range(10)),
         DocumentArray(
             [
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                Document(
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                ),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),
@@ -52,7 +54,9 @@ def test_index_search(make_search_flow, inputs, limit):
         lambda: (Document(text='hello, world') for _ in range(10)),
         DocumentArray(
             [
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                Document(
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                ),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,9 +15,7 @@ from clip_client import Client
         lambda: (Document(text='hello, world') for _ in range(10)),
         DocumentArray(
             [
-                Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
-                ),
+                Document(uri='https://clip-as-service.jina.ai/_static/favicon.png'),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),
@@ -54,9 +52,7 @@ def test_index_search(make_search_flow, inputs, limit):
         lambda: (Document(text='hello, world') for _ in range(10)),
         DocumentArray(
             [
-                Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
-                ),
+                Document(uri='https://clip-as-service.jina.ai/_static/favicon.png'),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ import numpy as np
 
 def test_server_download(tmpdir):
     download_model(
-        url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+        url='https://clip-as-service.jina.ai/_static/favicon.png',
         target_folder=tmpdir,
         md5sum='66ea4817d73514888dcf6c7d2b00016d',
         with_resume=False,
@@ -27,7 +27,7 @@ def test_server_download(tmpdir):
     os.remove(target_path)
 
     download_model(
-        url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+        url='https://clip-as-service.jina.ai/_static/favicon.png',
         target_folder=tmpdir,
         md5sum='66ea4817d73514888dcf6c7d2b00016d',
         with_resume=True,
@@ -40,7 +40,7 @@ def test_server_download(tmpdir):
 def test_server_download_md5(tmpdir, md5):
     if md5 != 'ABC':
         download_model(
-            url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+            url='https://clip-as-service.jina.ai/_static/favicon.png',
             target_folder=tmpdir,
             md5sum=md5,
             with_resume=False,
@@ -48,7 +48,7 @@ def test_server_download_md5(tmpdir, md5):
     else:
         with pytest.raises(Exception):
             download_model(
-                url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                url='https://clip-as-service.jina.ai/_static/favicon.png',
                 target_folder=tmpdir,
                 md5sum=md5,
                 with_resume=False,
@@ -58,7 +58,7 @@ def test_server_download_md5(tmpdir, md5):
 def test_server_download_not_regular_file(tmpdir):
     with pytest.raises(Exception):
         download_model(
-            url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+            url='https://clip-as-service.jina.ai/_static/favicon.png',
             target_folder=tmpdir,
             md5sum='',
             with_resume=False,
@@ -87,7 +87,7 @@ def test_make_onnx_flow_wrong_name_path():
     'image_uri',
     [
         f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg',
-        'https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+        'https://clip-as-service.jina.ai/_static/favicon.png',
     ],
 )
 @pytest.mark.parametrize('size', [224, 288, 384, 448])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ import numpy as np
 
 def test_server_download(tmpdir):
     download_model(
-        url='https://docarray.jina.ai/_static/favicon.png',
+        url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
         target_folder=tmpdir,
         md5sum='66ea4817d73514888dcf6c7d2b00016d',
         with_resume=False,
@@ -27,7 +27,7 @@ def test_server_download(tmpdir):
     os.remove(target_path)
 
     download_model(
-        url='https://docarray.jina.ai/_static/favicon.png',
+        url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
         target_folder=tmpdir,
         md5sum='66ea4817d73514888dcf6c7d2b00016d',
         with_resume=True,
@@ -40,7 +40,7 @@ def test_server_download(tmpdir):
 def test_server_download_md5(tmpdir, md5):
     if md5 != 'ABC':
         download_model(
-            url='https://docarray.jina.ai/_static/favicon.png',
+            url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
             target_folder=tmpdir,
             md5sum=md5,
             with_resume=False,
@@ -48,7 +48,7 @@ def test_server_download_md5(tmpdir, md5):
     else:
         with pytest.raises(Exception):
             download_model(
-                url='https://docarray.jina.ai/_static/favicon.png',
+                url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                 target_folder=tmpdir,
                 md5sum=md5,
                 with_resume=False,
@@ -58,7 +58,7 @@ def test_server_download_md5(tmpdir, md5):
 def test_server_download_not_regular_file(tmpdir):
     with pytest.raises(Exception):
         download_model(
-            url='https://docarray.jina.ai/_static/favicon.png',
+            url='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
             target_folder=tmpdir,
             md5sum='',
             with_resume=False,
@@ -87,7 +87,7 @@ def test_make_onnx_flow_wrong_name_path():
     'image_uri',
     [
         f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg',
-        'https://docarray.jina.ai/_static/favicon.png',
+        'https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
     ],
 )
 @pytest.mark.parametrize('size', [224, 288, 384, 448])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,7 @@ def test_server_download(tmpdir):
     download_model(
         url='https://clip-as-service.jina.ai/_static/favicon.png',
         target_folder=tmpdir,
-        md5sum='66ea4817d73514888dcf6c7d2b00016d',
+        md5sum='43104e468ddd23c55bc662d84c87a7f8',
         with_resume=False,
     )
     target_path = os.path.join(tmpdir, 'favicon.png')
@@ -29,7 +29,7 @@ def test_server_download(tmpdir):
     download_model(
         url='https://clip-as-service.jina.ai/_static/favicon.png',
         target_folder=tmpdir,
-        md5sum='66ea4817d73514888dcf6c7d2b00016d',
+        md5sum='43104e468ddd23c55bc662d84c87a7f8',
         with_resume=True,
     )
     assert os.path.getsize(target_path) == file_size

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,7 +36,7 @@ def test_server_download(tmpdir):
     assert not os.path.exists(part_path)
 
 
-@pytest.mark.parametrize('md5', ['ABC', None, '66ea4817d73514888dcf6c7d2b00016d'])
+@pytest.mark.parametrize('md5', ['ABC', None, '43104e468ddd23c55bc662d84c87a7f8'])
 def test_server_download_md5(tmpdir, md5):
     if md5 != 'ABC':
         download_model(

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -35,7 +35,7 @@ def test_protocols(port_generator, protocol, jit, pytestconfig):
         ('hello, world', 'goodbye, world'),
         lambda: ('hello, world' for _ in range(10)),
         [
-            'https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+            'https://clip-as-service.jina.ai/_static/favicon.png',
             f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg',
             'hello, world',
         ],
@@ -58,9 +58,7 @@ def test_plain_inputs(make_flow, inputs):
         lambda: (Document(text='hello, world') for _ in range(10)),
         DocumentArray(
             [
-                Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
-                ),
+                Document(uri='https://clip-as-service.jina.ai/_static/favicon.png'),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),
@@ -92,7 +90,7 @@ def test_docarray_inputs(make_flow, inputs):
         DocumentArray(
             [
                 Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                    uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     text='hello, world',
                 ),
             ]
@@ -119,7 +117,7 @@ def test_docarray_preserve_original_inputs(make_flow, inputs):
         DocumentArray(
             [
                 Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+                    uri='https://clip-as-service.jina.ai/_static/favicon.png',
                     text='hello, world',
                 ),
             ]

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -35,7 +35,7 @@ def test_protocols(port_generator, protocol, jit, pytestconfig):
         ('hello, world', 'goodbye, world'),
         lambda: ('hello, world' for _ in range(10)),
         [
-            'https://docarray.jina.ai/_static/favicon.png',
+            'https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
             f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg',
             'hello, world',
         ],
@@ -58,7 +58,9 @@ def test_plain_inputs(make_flow, inputs):
         lambda: (Document(text='hello, world') for _ in range(10)),
         DocumentArray(
             [
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                Document(
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                ),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),
@@ -90,7 +92,7 @@ def test_docarray_inputs(make_flow, inputs):
         DocumentArray(
             [
                 Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     text='hello, world',
                 ),
             ]
@@ -117,7 +119,7 @@ def test_docarray_preserve_original_inputs(make_flow, inputs):
         DocumentArray(
             [
                 Document(
-                    uri='https://docarray.jina.ai/_static/favicon.png',
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
                     text='hello, world',
                 ),
             ]

--- a/tests/test_tensorrt.py
+++ b/tests/test_tensorrt.py
@@ -17,9 +17,7 @@ from clip_client.client import Client
         lambda: (Document(text='hello, world') for _ in range(10)),
         DocumentArray(
             [
-                Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
-                ),
+                Document(uri='https://clip-as-service.jina.ai/_static/favicon.png'),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),
@@ -49,15 +47,13 @@ def test_docarray_inputs(make_trt_flow, inputs):
     'd',
     [
         Document(
-            uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
+            uri='https://clip-as-service.jina.ai/_static/favicon.png',
             matches=[Document(text='hello, world'), Document(text='goodbye, world')],
         ),
         Document(
             text='hello, world',
             matches=[
-                Document(
-                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
-                ),
+                Document(uri='https://clip-as-service.jina.ai/_static/favicon.png'),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),

--- a/tests/test_tensorrt.py
+++ b/tests/test_tensorrt.py
@@ -17,7 +17,9 @@ from clip_client.client import Client
         lambda: (Document(text='hello, world') for _ in range(10)),
         DocumentArray(
             [
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                Document(
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                ),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),
@@ -47,13 +49,15 @@ def test_docarray_inputs(make_trt_flow, inputs):
     'd',
     [
         Document(
-            uri='https://docarray.jina.ai/_static/favicon.png',
+            uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png',
             matches=[Document(text='hello, world'), Document(text='goodbye, world')],
         ),
         Document(
             text='hello, world',
             matches=[
-                Document(uri='https://docarray.jina.ai/_static/favicon.png'),
+                Document(
+                    uri='https://raw.githubusercontent.com/jina-ai/clip-as-service/main/docs/_static/favicon.png'
+                ),
                 Document(
                     uri=f'{os.path.dirname(os.path.abspath(__file__))}/img/00000.jpg'
                 ),


### PR DESCRIPTION
There is a package conflict with `onnxruntime` and `onnxruntime-gpu` in setup. If we install both packages, we are not able to run onnx using gpu. Installing only `onnxruntime-gpu` enables clip_server to run both on CPU and GPU.

This PR also corrects the instructions on running docker image in different runtimes.

This PR also replaces the broken images in test files

Notes: onnxruntime is fixed at 1.13.1 to pass the test_ranker
nvidia-tensorrt is fixed at 8.4.1.5 to pass trt related tests